### PR TITLE
PDF Skills in chronological order

### DIFF
--- a/src/exporter/pdf_exporter.py
+++ b/src/exporter/pdf_exporter.py
@@ -9,6 +9,7 @@ from reportlab.lib.pagesizes import LETTER
 from reportlab.platypus import SimpleDocTemplate, Paragraph, Spacer, Table, TableStyle
 from reportlab.lib.styles import getSampleStyleSheet
 from reportlab.lib import colors
+import os
 
 
 
@@ -121,32 +122,51 @@ def export(data, llm_response=None,filename="report.pdf", consent="y"):
 def collect_predictions(parsed_folder):
     """
     Collects predictions from parsed file summaries.
-    Returns a flat list of ["filename: skill", probability].
+    Returns a flat list of ["filename: skill", probability] sorted
+    by file modification time (newest first).
     """
+
+    if not isinstance(parsed_folder, list):
+        print("⚠️ Unexpected parsed_folder structure. PDF will be empty.")
+        return []
+
+    files_with_mtime = []
+
+    # Attach modification times
+    for file_summary in parsed_folder:
+        file_name = file_summary.get("file", "Unknown file")
+
+        # Only set mtime if the file exists on disk
+        if os.path.exists(file_name):
+            mtime = os.path.getmtime(file_name)
+        else:
+            mtime = 0  # fallback if file path is missing
+        files_with_mtime.append((file_summary, mtime))
+
+    # Sort files from newest to oldest
+    files_with_mtime.sort(key=lambda x: x[1], reverse=True)
 
     all_predictions = []
 
-    if isinstance(parsed_folder, list):
-        for file_summary in parsed_folder:
-            file_name = file_summary.get("file", "Unknown file")
+    # Collect predictions in sorted order
+    for file_summary, _ in files_with_mtime:
+        file_name = file_summary.get("file", "Unknown file")
 
-            # Accept both "skills" and "predictions"
-            skills = (
-                file_summary.get("skills")
-                or file_summary.get("predictions")
-                or []
-            )
+        # Accept both "skills" and "predictions" fields
+        skills = (
+            file_summary.get("skills")
+            or file_summary.get("predictions")
+            or []
+        )
 
-            if not isinstance(skills, list):
-                continue
+        if not isinstance(skills, list):
+            continue
 
-            for item in skills:
-                if isinstance(item, (list, tuple)) and len(item) == 2:
-                    skill, prob = item
-                    all_predictions.append([f"{file_name}: {skill}", prob])
-                else:
-                    print(f"⚠️ Skipping invalid skill entry in {file_name}: {item}")
-    else:
-        print("⚠️ Unexpected parsed_folder structure. PDF will be empty.")
+        for item in skills:
+            if isinstance(item, (list, tuple)) and len(item) == 2:
+                skill, prob = item
+                all_predictions.append([f"{file_name}: {skill}", prob])
+            else:
+                print(f"⚠️ Skipping invalid skill entry in {file_name}: {item}")
 
     return all_predictions

--- a/src/validator/zipvalidation.py
+++ b/src/validator/zipvalidation.py
@@ -1,5 +1,6 @@
 import os
 import zipfile
+import time
 
 
 def check_zip_file(file_path):
@@ -26,9 +27,15 @@ def unzip_file(zip_path, extract_dir=None):
     # Ensure extraction directory exists
     os.makedirs(extract_dir, exist_ok=True)
 
-    # Extract contents
+    # Extract contents and preserve original modification times
     with zipfile.ZipFile(zip_path, "r") as zip_ref:
-        zip_ref.extractall(extract_dir)
+        for info in zip_ref.infolist():
+            extracted_path = zip_ref.extract(info, path=extract_dir)
+
+            # Convert info.date_time tuple to timestamp
+            mod_time = time.mktime(info.date_time + (0, 0, -1))
+            # Update file's access and modification times
+            os.utime(extracted_path, (mod_time, mod_time))
 
     # Return ONLY the real directory path
     return extract_dir


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

> Please include a summary of the change and which issue is fixed.  
> Include relevant motivation and context.  
> List any dependencies that are required for this change.
This PR contains

- An improvement to the the exporter where the predicted skills are now outputted in chronological order
- a necessary change to the validator that now allwos for modification times for files to be "snapshotted" before any parsing or other operations

**Closes:** # 158

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated
- [✅ ] ♻️ Refactoring
- [✅ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [ ✅] Test A - Manual Run - PDF now has predicted skills in chronological order (see pdf and file  explorer screenshots to see how this looks)
- [ ✅] Test B - Pytest - Pytests all pass, see screenshot below

---

## ✓ Checklist

- [✅ ] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ✅] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [ ✅] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->
<img width="1376" height="106" alt="pytest_passing dec_7" src="https://github.com/user-attachments/assets/7ea82dff-997d-407b-b122-e0270ee9ecfe" />
<img width="850" height="370" alt="chronoloical order pdf" src="https://github.com/user-attachments/assets/c2b10848-7448-49e8-8104-0ad7cd2d5d56" />
<img width="731" height="148" alt="chronological ordr mtimes" src="https://github.com/user-attachments/assets/750bffca-b3a9-47a8-861d-e6c1e428a7bc" />


</details>