### PR TITLE
GET projects/{project_id} now returns evidence

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -1297,6 +1297,7 @@ def get_project_by_id(project_id: str):
                   pr.collaboration_type,
                   pr.user_role,
                   pr.created_at,
+                  pr.evidence_json,
                   COALESCE(t.total_commits, 0) AS total_commits,
                   COALESCE(ut.user_commits, 0) AS user_commits,
                   COALESCE(t.contributor_count, 0) AS contributor_count,
@@ -1317,6 +1318,10 @@ def get_project_by_id(project_id: str):
 
         # Convert to dict and format metrics as seen in list_projects
         res = dict(row)
+
+        # Pop and rename for api response
+        res["evidence"] = res.pop("evidence_json") or {}
+
         res["metrics"] = {
             "total_commits": int(res.pop("total_commits")),
             "user_commits": int(res.pop("user_commits")) or None,

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -879,6 +879,38 @@ def test_project_patch_persists_user_role_and_evidence_end_to_end(client, engine
     resume_project = r_resume.json()["content"]["project"]
     assert resume_project["user_role"] == "Technical Lead"
 
+def test_get_project_by_id_surfaces_evidence(client, engine):
+    """
+    Test for the fix: GET /projects/{project_id} must return 'evidence'
+    derived from 'evidence_json' in the database.
+    """
+    _, _, project_id, _ = _mk_graph(engine)
+
+    test_evidence = {
+        "metrics": {"velocity": 10, "quality": "high"},
+        "feedback": "Great work on the endpoint.",
+        "evaluation": "Exceeds expectations"
+    }
+
+    # PATCH the evidence using "evidence_json" as the key here because that's what PATCH expects
+    patch_response = client.patch(
+        f"/projects/{project_id}",
+        json={"evidence_json": test_evidence}
+    )
+    assert patch_response.status_code == 200
+
+    # GET the project
+    get_response = client.get(f"/projects/{project_id}")
+    assert get_response.status_code == 200
+    
+    data = get_response.json()
+    
+    # Assertions
+    assert "evidence" in data, "The 'evidence' key is missing from the response!"
+    assert data["evidence"] == test_evidence, "The evidence data does not match what was saved!"
+    
+    # Verify we aren't leaking the internal DB column name
+    assert "evidence_json" not in data
 
 def test_project_patch_updates_targeted_evidence_sections(client, engine):
     _, _, project_id, _ = _mk_graph(engine)


### PR DESCRIPTION
<!-- 
Thank you for contributing! Please fill out this template to help us review your PR.
-->

## 📝 Description

> Please include a summary of the change and which issue is fixed.  
> Include relevant motivation and context.  
> List any dependencies that are required for this change.

Fixed data asymmetry in the Project details endpoint. While project evidence (metrics, feedback, etc.) was successfully being persisted via PATCH, it was not being returned in the GET response. Kudos to Liam for finding this.

Changes:
- Updated GET /projects/{project_id} SQL query to include the evidence_json column.
- Mapped evidence_json to a clean evidence key in the API response.
- Implemented a null-safety fallback (or {}) to ensure the frontend always receives an object.
- Added an end-to-end integration test in test_api.py to verify the write-and-read round trip.

**Closes:** #251 

---

## 🔧 Type of Change

- [✅] 🐛 Bug fix (non-breaking change that fixes an issue)
- [] ✨ New feature (non-breaking change that adds functionality)
- [] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [n/a] 📚 Documentation added/updated
- [✅] ✅ Test added/updated
- [] ♻️ Refactoring
- [] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

- [✅] Test A

Testing manually is as simple as using the localhost:5001 to access the endpoints and then add a project, patch it, and get it, and confirm that it does in fact return the evidence which I tested successfully.

- [✅] Test B

In the pytest suite I added a test titled: `test_get_project_by_id_surfaces_evidence` which tests creating a project, patching it, and then getting it and confirming the evidence is there with the correct name and content. The test is passing consistently.

---

## ✓ Checklist

- [✅] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [✅] 💬 I have commented my code where needed
- [n/a] 📖 I have made corresponding changes to the documentation
- [✅] ⚠️ My changes generate no new warnings
- [✅] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [n/a] 🔗 Any dependent changes have been merged and published in downstream modules
- [n/a] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add your screenshots here -->

</details>
