### PR TITLE
Dashboard mode UI and public portfolio view

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ src/ml/data/
 .pytest_cache
 artifactminer_state.json
 node_modules
+blobstore/

--- a/Dockerfile.api
+++ b/Dockerfile.api
@@ -4,6 +4,7 @@ WORKDIR /app
 
 ENV PYTHONDONTWRITEBYTECODE=1
 ENV PYTHONUNBUFFERED=1
+ENV ARTIFACT_MINER_BLOBSTORE=/blobstore
 
 # No build toolchain needed because we use psycopg2-binary for API
 RUN apt-get update && apt-get install -y --no-install-recommends \
@@ -20,4 +21,5 @@ COPY src/db /app/src/db
 COPY src/api /app/src/api
 
 EXPOSE 5000
+VOLUME ["/blobstore"]
 CMD ["uvicorn", "src.api.app:app", "--host", "0.0.0.0", "--port", "5000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,6 +28,9 @@ services:
     container_name: artifactminer-migrate
     environment:
       DATABASE_URL: postgresql+psycopg2://postgres:postgres@db:5432/artifactminer
+      ARTIFACT_MINER_BLOBSTORE: /blobstore
+    volumes:
+      - blobstore:/blobstore
     depends_on:
       db:
         condition: service_healthy

--- a/docs/api/README_API.md
+++ b/docs/api/README_API.md
@@ -275,6 +275,31 @@ Resume PDF filters are read from `config.resume_filters` (optional):
     - `title` (optional)
     - `summary_text` (optional)
 
+- Dashboard mode/publish endpoints (owner-authenticated):
+  - `GET /portfolio/{portfolio_id}/dashboard/mode`
+    - Returns mode state, `public_slug`, active publication metadata.
+  - `POST /portfolio/{portfolio_id}/dashboard/mode`
+    - Body: `{ "mode": "private" | "public" }`
+    - Switching to `public` requires an existing published snapshot.
+  - `POST /portfolio/{portfolio_id}/dashboard/publish`
+    - Freezes current dashboard config + data as a new immutable publication.
+    - Also switches dashboard mode to `public`.
+  - `POST /portfolio/{portfolio_id}/dashboard/unpublish`
+    - Switches mode back to `private` (previous publication is retained).
+  - `POST /portfolio/{portfolio_id}/dashboard/public-link/regenerate`
+    - Rotates the portfolio's public slug.
+
+- Public read endpoint:
+  - `GET /public/portfolio/{public_slug}`
+    - Public-mode read-only dashboard payload.
+    - Supported query params only:
+      - `q`
+      - `date_from` / `date_to` (`YYYY-MM-DD`)
+      - `project_ids` (repeated or comma-separated)
+      - `skills` (repeated or comma-separated)
+      - `sort` (`rank_desc`, `rank_asc`, `name_asc`, `name_desc`, `date_desc`, `date_asc`)
+    - Unknown query params return `400`.
+
 - `DELETE /portfolio/showcases/{showcase_id}`
   - Deletes showcase artifact and GC's unreferenced thumbnail blob.
 

--- a/docs/architecture/current-state.md
+++ b/docs/architecture/current-state.md
@@ -66,6 +66,16 @@ User-adjustable controls are stored under `user_config.config_json`:
 - `comparison`: default attributes for `/projects/compare`.
 - `highlights` and `showcase`: skill/project selections for generated outputs.
 
+## Dashboard Mode and Publish Flow
+- `portfolio_dashboards` tracks owner-facing mode state:
+  - `private`: draft/customization mode.
+  - `public`: public slug is live and serves a frozen publication.
+- `dashboard_publications` stores immutable snapshots of:
+  - frozen configuration payloads,
+  - frozen dashboard datasets,
+  - filter specification contract used by public mode.
+- Public route `GET /public/portfolio/{public_slug}` is read-only and only accepts the approved search/filter params.
+
 ## Consent-Gated External Behavior
 - External analysis execution is allowed only when latest `external_services` consent is granted.
 - Ingest in external modes (`external`, `both`) is blocked without consent.

--- a/docs/frontend/README.md
+++ b/docs/frontend/README.md
@@ -10,6 +10,8 @@ The frontend is a React app in `frontend/` (Create React App).
 - View top ranked projects.
 - View portfolio skills timeline.
 - Trigger resume generation and open generated PDF.
+- Publish/unpublish dashboard mode and share a public portfolio slug.
+- View read-only public portfolio route at `/portfolio/:publicSlug`.
 
 ## Run Frontend Locally
 ```bash

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -189,6 +189,20 @@ button {
   background: #fbfcff;
 }
 
+.stack-block details > summary,
+details.stack-block > summary {
+  cursor: pointer;
+  font-weight: 700;
+}
+
+.public-preview-frame {
+  width: 100%;
+  min-height: 780px;
+  border: 1px solid #dce5ff;
+  border-radius: 12px;
+  background: #ffffff;
+}
+
 .project-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(270px, 1fr));

--- a/frontend/src/App.js
+++ b/frontend/src/App.js
@@ -1,8 +1,19 @@
 import React from 'react';
 import './App.css';
 import Homepage from './Homepage.jsx';
+import PublicPortfolioView from './PublicPortfolioView.jsx';
+
+function getPublicSlugFromPath(pathname) {
+  const match = String(pathname || '').match(/^\/portfolio\/([a-zA-Z0-9_-]+)\/?$/);
+  return match ? match[1] : null;
+}
 
 function App() {
+  const publicSlug = getPublicSlugFromPath(window.location.pathname);
+  if (publicSlug) {
+    return <PublicPortfolioView publicSlug={publicSlug} />;
+  }
+
   return (
     <div>
       <Homepage />

--- a/frontend/src/Homepage.jsx
+++ b/frontend/src/Homepage.jsx
@@ -1,5 +1,5 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
-import { API_BASE_URL, authApi, projectApi, userConfigApi } from './api';
+import { API_BASE_URL, authApi, dashboardApi, projectApi, userConfigApi } from './api';
 
 const TOKEN_STORAGE_KEY = 'artifactMiner.authToken';
 const ANALYSIS_POLL_INTERVAL_MS = 5000;
@@ -425,6 +425,12 @@ function Homepage() {
   const [showcaseSaving, setShowcaseSaving] = useState(false);
   const [showcaseGenerating, setShowcaseGenerating] = useState(false);
   const [showcaseError, setShowcaseError] = useState('');
+  const [dashboardMode, setDashboardMode] = useState('private');
+  const [dashboardPublicSlug, setDashboardPublicSlug] = useState('');
+  const [publicPreviewVersion, setPublicPreviewVersion] = useState(0);
+  const [dashboardModeLoading, setDashboardModeLoading] = useState(false);
+  const [dashboardModeActionBusy, setDashboardModeActionBusy] = useState(false);
+  const [dashboardModeError, setDashboardModeError] = useState('');
 
   const isAuthenticated = Boolean(token && currentUser);
 
@@ -478,6 +484,12 @@ function Homepage() {
     setShowcaseSaving(false);
     setShowcaseGenerating(false);
     setShowcaseError('');
+    setDashboardMode('private');
+    setDashboardPublicSlug('');
+    setPublicPreviewVersion(0);
+    setDashboardModeLoading(false);
+    setDashboardModeActionBusy(false);
+    setDashboardModeError('');
     setView('projects');
   }, []);
 
@@ -605,6 +617,21 @@ function Homepage() {
     }
   }, [token, currentUser, applyRepresentationConfig]);
 
+  const fetchDashboardMode = useCallback(async () => {
+    if (!token || !portfolioId) return;
+    setDashboardModeLoading(true);
+    setDashboardModeError('');
+    try {
+      const response = await dashboardApi.getMode(token, portfolioId);
+      setDashboardMode(response?.mode || 'private');
+      setDashboardPublicSlug(response?.public_slug || '');
+    } catch (error) {
+      setDashboardModeError(error.message || 'Unable to load dashboard mode.');
+    } finally {
+      setDashboardModeLoading(false);
+    }
+  }, [token, portfolioId]);
+
   const fetchTopProjects = useCallback(async () => {
     if (!token || !portfolioId) return;
     setLoading(true);
@@ -650,6 +677,11 @@ function Homepage() {
     if (!isAuthenticated) return;
     fetchUserConfig();
   }, [isAuthenticated, fetchUserConfig]);
+
+  useEffect(() => {
+    if (!isAuthenticated || !portfolioId) return;
+    fetchDashboardMode();
+  }, [isAuthenticated, portfolioId, fetchDashboardMode]);
 
   useEffect(() => {
     if (!isAuthenticated) return;
@@ -937,6 +969,76 @@ function Homepage() {
     } finally {
       clearSession();
     }
+  };
+
+  const publishDashboard = async () => {
+    if (!token || !portfolioId) return;
+    setDashboardModeActionBusy(true);
+    setDashboardModeError('');
+    setDashboardError('');
+    try {
+      const response = await dashboardApi.publish(token, portfolioId);
+      setDashboardMode(response?.mode || 'public');
+      setDashboardPublicSlug(response?.public_slug || '');
+      setPublicPreviewVersion((version) => version + 1);
+      setFlashMessage('Dashboard published. Public mode is now live.');
+    } catch (error) {
+      setDashboardModeError(error.message || 'Unable to publish dashboard.');
+    } finally {
+      setDashboardModeActionBusy(false);
+    }
+  };
+
+  const switchDashboardToPrivate = async () => {
+    if (!token || !portfolioId) return;
+    setDashboardModeActionBusy(true);
+    setDashboardModeError('');
+    try {
+      const response = await dashboardApi.unpublish(token, portfolioId);
+      setDashboardMode(response?.mode || 'private');
+      setDashboardPublicSlug(response?.public_slug || dashboardPublicSlug);
+      setPublicPreviewVersion((version) => version + 1);
+      setFlashMessage('Dashboard switched to private mode.');
+    } catch (error) {
+      setDashboardModeError(error.message || 'Unable to switch dashboard to private mode.');
+    } finally {
+      setDashboardModeActionBusy(false);
+    }
+  };
+
+  const regeneratePublicLink = async () => {
+    if (!token || !portfolioId) return;
+    setDashboardModeActionBusy(true);
+    setDashboardModeError('');
+    try {
+      const response = await dashboardApi.regeneratePublicLink(token, portfolioId);
+      setDashboardPublicSlug(response?.public_slug || '');
+      setPublicPreviewVersion((version) => version + 1);
+      setFlashMessage('Public link regenerated.');
+    } catch (error) {
+      setDashboardModeError(error.message || 'Unable to regenerate public link.');
+    } finally {
+      setDashboardModeActionBusy(false);
+    }
+  };
+
+  const copyPublicLink = async () => {
+    if (!dashboardPublicSlug) return;
+    const url = `${window.location.origin}/portfolio/${dashboardPublicSlug}`;
+    try {
+      await navigator.clipboard.writeText(url);
+      setFlashMessage('Public link copied to clipboard.');
+    } catch (error) {
+      setDashboardModeError('Unable to copy public link. Copy it manually from the URL preview.');
+    }
+  };
+
+  const toggleDashboardVisibility = async () => {
+    if (dashboardMode === 'public') {
+      await switchDashboardToPrivate();
+      return;
+    }
+    await publishDashboard();
   };
 
   const handleUpload = async () => {
@@ -1607,6 +1709,7 @@ function Homepage() {
   const navButtons = useMemo(
     () => [
       { id: 'projects', label: 'Projects' },
+      { id: 'dashboardMode', label: 'Dashboard Mode' },
       { id: 'preferences', label: 'Preferences' },
       { id: 'compare', label: 'Compare' },
       { id: 'upload', label: 'Upload' },
@@ -1711,6 +1814,16 @@ function Homepage() {
     () => projects.find((project) => project.id === uploadTargetProjectId) || null,
     [projects, uploadTargetProjectId]
   );
+
+  const publicPortfolioUrl = useMemo(() => {
+    if (!dashboardPublicSlug) return '';
+    return `${window.location.origin}/portfolio/${dashboardPublicSlug}`;
+  }, [dashboardPublicSlug]);
+
+  const publicPreviewUrl = useMemo(() => {
+    if (!publicPortfolioUrl) return '';
+    return `${publicPortfolioUrl}?preview=${publicPreviewVersion}`;
+  }, [publicPortfolioUrl, publicPreviewVersion]);
 
   const uploadSnapshotHistory = useMemo(() => {
     const snapshots = Array.isArray(uploadTargetReport?.snapshots) ? uploadTargetReport.snapshots : [];
@@ -1951,6 +2064,71 @@ function Homepage() {
             </section>
           )}
 
+          {view === 'dashboardMode' && (
+            <section className="panel">
+              <h2>Dashboard Mode</h2>
+              <div className="stack-block">
+                <div className="panel-title-row">
+                  <div>
+                    <p className="muted">
+                      Current mode:{' '}
+                      <strong>{dashboardModeLoading ? 'Loading...' : dashboardMode === 'public' ? 'Public' : 'Private'}</strong>
+                    </p>
+                    {publicPortfolioUrl && <p className="muted">Public URL: {publicPortfolioUrl}</p>}
+                  </div>
+                  <div className="card-actions">
+                    <button
+                      className="primary-btn"
+                      type="button"
+                      onClick={toggleDashboardVisibility}
+                      disabled={dashboardModeActionBusy || dashboardModeLoading}
+                    >
+                      {dashboardModeActionBusy
+                        ? 'Working...'
+                        : dashboardMode === 'public'
+                          ? 'Make Private'
+                          : 'Make Public'}
+                    </button>
+                    <button
+                      className="secondary-btn"
+                      type="button"
+                      onClick={regeneratePublicLink}
+                      disabled={dashboardModeActionBusy || dashboardModeLoading}
+                    >
+                      Regenerate Link
+                    </button>
+                    <button
+                      className="ghost-btn"
+                      type="button"
+                      onClick={copyPublicLink}
+                      disabled={!dashboardPublicSlug || dashboardModeLoading}
+                    >
+                      Copy Public URL
+                    </button>
+                  </div>
+                </div>
+                {dashboardModeError && <p className="error-banner inline-error">{dashboardModeError}</p>}
+              </div>
+
+              <div className="stack-block">
+                <h3>Public Preview</h3>
+                <p className="muted">This is what others see at your public URL.</p>
+                {!publicPortfolioUrl ? (
+                  <p className="muted">Public URL not available yet.</p>
+                ) : dashboardMode !== 'public' ? (
+                  <p className="muted">Your profile is private. Switch to public mode to enable public viewing.</p>
+                ) : (
+                  <iframe
+                    key={`${dashboardMode}:${dashboardPublicSlug}:${publicPreviewVersion}`}
+                    className="public-preview-frame"
+                    src={publicPreviewUrl}
+                    title="Public portfolio preview"
+                  />
+                )}
+              </div>
+            </section>
+          )}
+
           {view === 'preferences' && (
             <section className="panel">
               <h2>Preferences</h2>
@@ -2169,7 +2347,12 @@ function Homepage() {
                       )}
                     </div>
 
-                    <button className="primary-btn" type="button" onClick={saveRepresentationPreferences} disabled={configSaving}>
+                    <button
+                      className="primary-btn"
+                      type="button"
+                      onClick={saveRepresentationPreferences}
+                      disabled={configSaving}
+                    >
                       {configSaving ? 'Saving preferences...' : 'Save Representation Preferences'}
                     </button>
                     {userConfig && <p className="muted">Preferences are saved to your profile-level user configuration.</p>}

--- a/frontend/src/PublicPortfolioView.jsx
+++ b/frontend/src/PublicPortfolioView.jsx
@@ -1,0 +1,185 @@
+import React, { useCallback, useEffect, useMemo, useState } from 'react';
+import { dashboardApi } from './api';
+
+function toCsvList(value) {
+  return String(value || '')
+    .split(',')
+    .map((entry) => entry.trim())
+    .filter(Boolean);
+}
+
+function readFiltersFromUrl() {
+  const params = new URLSearchParams(window.location.search);
+  return {
+    q: params.get('q') || '',
+    date_from: params.get('date_from') || '',
+    date_to: params.get('date_to') || '',
+    sort: params.get('sort') || 'rank_desc',
+    project_ids: params.getAll('project_ids'),
+    skills: params.getAll('skills'),
+  };
+}
+
+function writeFiltersToUrl(filters) {
+  const params = new URLSearchParams();
+  if (filters.q) params.set('q', filters.q);
+  if (filters.date_from) params.set('date_from', filters.date_from);
+  if (filters.date_to) params.set('date_to', filters.date_to);
+  if (filters.sort) params.set('sort', filters.sort);
+  (filters.project_ids || []).forEach((v) => v && params.append('project_ids', v));
+  (filters.skills || []).forEach((v) => v && params.append('skills', v));
+  const query = params.toString();
+  window.history.replaceState({}, '', `${window.location.pathname}${query ? `?${query}` : ''}`);
+}
+
+function formatDateOnly(value) {
+  if (!value) return 'N/A';
+  const parsed = new Date(value);
+  return Number.isNaN(parsed.getTime()) ? 'N/A' : parsed.toLocaleDateString();
+}
+
+function Section({ title, empty, children }) {
+  return (
+    <section className="panel">
+      <h2>{title}</h2>
+      {empty ? <p className="muted">{empty}</p> : children}
+    </section>
+  );
+}
+
+function PublicPortfolioView({ publicSlug }) {
+  const urlFilters = useMemo(() => readFiltersFromUrl(), []);
+  const [q, setQ] = useState(urlFilters.q);
+  const [dateFrom, setDateFrom] = useState(urlFilters.date_from);
+  const [dateTo, setDateTo] = useState(urlFilters.date_to);
+  const [skillsInput, setSkillsInput] = useState((urlFilters.skills || []).join(', '));
+  const [projectIdsInput, setProjectIdsInput] = useState((urlFilters.project_ids || []).join(', '));
+  const [sort, setSort] = useState(urlFilters.sort || 'rank_desc');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [payload, setPayload] = useState(null);
+
+  const loadDashboard = useCallback(
+    async (filters) => {
+      setLoading(true);
+      setError('');
+      try {
+        setPayload(await dashboardApi.getPublicDashboard(publicSlug, filters));
+      } catch (err) {
+        setError(err.message || 'Unable to load public portfolio.');
+        setPayload(null);
+      } finally {
+        setLoading(false);
+      }
+    },
+    [publicSlug]
+  );
+
+  useEffect(() => {
+    loadDashboard({
+      q: urlFilters.q || undefined,
+      date_from: urlFilters.date_from || undefined,
+      date_to: urlFilters.date_to || undefined,
+      sort: urlFilters.sort || 'rank_desc',
+      project_ids: urlFilters.project_ids || [],
+      skills: urlFilters.skills || [],
+    });
+  }, [loadDashboard, urlFilters]);
+
+  const applyFilters = async (event) => {
+    event.preventDefault();
+    const filters = {
+      q: q.trim() || undefined,
+      date_from: dateFrom || undefined,
+      date_to: dateTo || undefined,
+      sort,
+      project_ids: toCsvList(projectIdsInput),
+      skills: toCsvList(skillsInput),
+    };
+    writeFiltersToUrl(filters);
+    await loadDashboard(filters);
+  };
+
+  const dashboard = payload?.dashboard || {};
+  const projects = dashboard.projects || [];
+  const topProjects = dashboard.top_projects || [];
+  const skillsTimeline = dashboard.skills_timeline || [];
+  const heatmap = dashboard.activity_heatmap || [];
+  const showcases = dashboard.showcases || [];
+  const ownerUsername = payload?.owner?.username || payload?.owner?.display_name || 'User';
+
+  return (
+    <div className="screen-shell">
+      <div className="dashboard-shell">
+        <header className="dashboard-header">
+          <div>
+            <p className="eyebrow">Public Portfolio</p>
+            <h1>{ownerUsername}</h1>
+          </div>
+        </header>
+
+        {error && <p className="error-banner">{error}</p>}
+
+        <section className="panel">
+          <details className="stack-block">
+            <summary>Search and Filters</summary>
+            <form className="stack-block" onSubmit={applyFilters}>
+              <label className="field">Search<input type="text" value={q} onChange={(event) => setQ(event.target.value)} placeholder="Project or skill" /></label>
+              <div className="summary-grid">
+                <label className="field">Date from<input type="date" value={dateFrom} onChange={(event) => setDateFrom(event.target.value)} /></label>
+                <label className="field">Date to<input type="date" value={dateTo} onChange={(event) => setDateTo(event.target.value)} /></label>
+              </div>
+              <label className="field">Skills (comma-separated)<input type="text" value={skillsInput} onChange={(event) => setSkillsInput(event.target.value)} /></label>
+              <label className="field">Project IDs (comma-separated)<input type="text" value={projectIdsInput} onChange={(event) => setProjectIdsInput(event.target.value)} /></label>
+              <label className="field">
+                Sort
+                <select value={sort} onChange={(event) => setSort(event.target.value)}>
+                  <option value="rank_desc">Rank (high to low)</option>
+                  <option value="rank_asc">Rank (low to high)</option>
+                  <option value="name_asc">Name (A-Z)</option>
+                  <option value="name_desc">Name (Z-A)</option>
+                  <option value="date_desc">Date (newest first)</option>
+                  <option value="date_asc">Date (oldest first)</option>
+                </select>
+              </label>
+              <button className="primary-btn" type="submit" disabled={loading}>{loading ? 'Applying...' : 'Apply Filters'}</button>
+            </form>
+          </details>
+        </section>
+
+        {loading ? (
+          <Section title="Loading" empty="Loading public dashboard..." />
+        ) : (
+          <>
+            <Section title="Projects" empty={projects.length === 0 ? 'No projects match current filters.' : ''}>
+              <div className="project-grid">{projects.map((project) => <article key={project.id} className="project-card"><h3>{project.name}</h3><p>Created: {project.created_at || 'N/A'}</p><p>Rank score: {project.metrics?.rank_score ?? 'N/A'}</p></article>)}</div>
+            </Section>
+
+            <Section title="Top Projects" empty={topProjects.length === 0 ? 'No top projects available.' : ''}>
+              <div className="top-list">{topProjects.map((project) => <article key={project.project_id} className="top-card"><h3>{project.project_name || project.name || project.project_id}</h3><p>Rank score: {project.rank_score ?? 'N/A'}</p></article>)}</div>
+            </Section>
+
+            <Section title="Skills Timeline" empty={skillsTimeline.length === 0 ? 'No timeline events for current filters.' : ''}>
+              <div className="timeline">{skillsTimeline.map((event, index) => <article key={`${event.project_id}-${event.skill}-${index}`} className="timeline-item"><p className="timeline-date">{formatDateOnly(event.first_seen_ts)}</p><div><h3>{event.skill}</h3><p className="muted">{event.project_name || event.project_id}</p></div></article>)}</div>
+            </Section>
+
+            <Section title="Activity Heatmap Buckets" empty={heatmap.length === 0 ? 'No activity buckets for current filters.' : ''}>
+              <div className="table-wrap">
+                <table>
+                  <thead><tr><th>Date</th><th>Activity Count</th></tr></thead>
+                  <tbody>{heatmap.map((bucket, index) => <tr key={`${bucket.bucket_date}-${index}`}><td>{formatDateOnly(bucket.bucket_date)}</td><td>{bucket.activity_count ?? 0}</td></tr>)}</tbody>
+                </table>
+              </div>
+            </Section>
+
+            <Section title="Showcase Items" empty={showcases.length === 0 ? 'No showcase items available.' : ''}>
+              <div className="project-grid">{showcases.map((showcase) => <article key={showcase.id} className="project-card"><h3>{showcase.content?.title || showcase.project_name || showcase.project_id}</h3><p className="muted">{showcase.content?.summary_text || 'No summary saved.'}</p></article>)}</div>
+            </Section>
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default PublicPortfolioView;

--- a/frontend/src/api.js
+++ b/frontend/src/api.js
@@ -236,4 +236,45 @@ export const userConfigApi = {
     }),
 };
 
+export const dashboardApi = {
+  getMode: (token, portfolioId) => apiRequest(`/portfolio/${portfolioId}/dashboard/mode`, { token }),
+  setMode: (token, portfolioId, mode) =>
+    apiRequest(`/portfolio/${portfolioId}/dashboard/mode`, {
+      method: 'POST',
+      token,
+      body: { mode },
+    }),
+  publish: (token, portfolioId) =>
+    apiRequest(`/portfolio/${portfolioId}/dashboard/publish`, {
+      method: 'POST',
+      token,
+    }),
+  unpublish: (token, portfolioId) =>
+    apiRequest(`/portfolio/${portfolioId}/dashboard/unpublish`, {
+      method: 'POST',
+      token,
+    }),
+  regeneratePublicLink: (token, portfolioId) =>
+    apiRequest(`/portfolio/${portfolioId}/dashboard/public-link/regenerate`, {
+      method: 'POST',
+      token,
+    }),
+  getPublicDashboard: (publicSlug, filters = {}) => {
+    const params = new URLSearchParams();
+    if (filters.q) params.set('q', String(filters.q));
+    if (filters.date_from) params.set('date_from', String(filters.date_from));
+    if (filters.date_to) params.set('date_to', String(filters.date_to));
+    if (filters.sort) params.set('sort', String(filters.sort));
+    (filters.project_ids || []).forEach((projectId) => {
+      if (projectId) params.append('project_ids', String(projectId));
+    });
+    (filters.skills || []).forEach((skill) => {
+      if (skill) params.append('skills', String(skill));
+    });
+    const queryString = params.toString();
+    const suffix = queryString ? `?${queryString}` : '';
+    return apiRequest(`/public/portfolio/${publicSlug}${suffix}`, { token: null });
+  },
+};
+
 export { API_BASE_URL };


### PR DESCRIPTION
## 📝 Description

Delivers the frontend/private-public user experience plus related docs and container config updates for the dashboard publication feature.

Scope in this PR:
- Frontend routing + public page:
  - `frontend/src/App.js` routes `/portfolio/:publicSlug` to public profile view.
  - `frontend/src/PublicPortfolioView.jsx` renders public dashboard data with collapsed-by-default filters.
- Dashboard Mode UI:
  - dedicated Dashboard Mode view in `frontend/src/Homepage.jsx`
  - public/private toggle, regenerate link, copy URL controls
  - private mode shows private-state message instead of preview iframe
  - preview refreshes immediately after mode/link actions
- UX details requested for milestone interpretation:
  - public page shows owner username
  - skills timeline displays date-only
- Frontend API additions in `frontend/src/api.js` for dashboard/public endpoints.
- Styling/docs/dev environment updates:
  - CSS support for public preview/filter UI
  - docs updates in API/frontend/architecture READMEs
  - blobstore docker defaults (`Dockerfile.api`, `docker-compose.yml`) and ignore rule for local `blobstore/`.

Stack order (merge in this exact order):
1. `issue-289-a-dashboard-core` -> `develop`
2. `issue-289-b-public-endpoint` -> `issue-289-a-dashboard-core`
3. `issue-289-c-guards-tests` -> `issue-289-b-public-endpoint`
4. `issue-289-d-frontend-docs` (this PR) -> `issue-289-c-guards-tests`

Dependencies:
- Depends on PR A/B/C backend contracts and tests.

**Closes:** #289

---

## 🔧 Type of Change

- [x] ✨ New feature (non-breaking change that adds functionality)
- [x] 📚 Documentation added/updated
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Validated with automated and manual testing in local development.
- Backend/feature test suite passes locally (`pytest`), including newly added dashboard tests from the stack.
- Manual browser validation completed for:
  - Dashboard Mode page controls (public/private toggle, regenerate/copy)
  - private-state preview messaging
  - immediate preview refresh after mode changes
  - public profile rendering and filter behavior (collapsed by default)
  - responsive behavior across desktop/mobile breakpoints.

- [x] Automated tests pass locally
- [x] Manual UI/API checks completed

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

Screenshots can be added during review if needed.

</details>
