### PR TITLE
Added changes to the UI and backend so that there is two modes: publi…

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -122,6 +122,59 @@ button {
   margin-bottom: 1rem;
 }
 
+.dashboard-header-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.75rem;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+}
+
+.mode-switch {
+  margin: 0;
+  padding: 0.4rem;
+  border: 1px solid #cdd8f6;
+  border-radius: 12px;
+  background: #ffffff;
+  display: flex;
+  align-items: center;
+  gap: 0.55rem;
+}
+
+.mode-switch-label {
+  margin: 0;
+  padding: 0 0.25rem;
+  font-size: 0.72rem;
+  font-weight: 700;
+  color: #5d6b86;
+}
+
+.mode-switch-option {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.25rem;
+  font-weight: 600;
+  color: #22304f;
+}
+
+.mode-switch-option input {
+  accent-color: #2e6cf4;
+}
+
+.mode-select {
+  border: 1px solid #cdd8f6;
+  border-radius: 8px;
+  padding: 0.38rem 0.55rem;
+  background: #ffffff;
+  color: #22304f;
+  font-weight: 600;
+  min-width: 120px;
+}
+
+.mode-switch:disabled {
+  opacity: 0.65;
+}
+
 .dashboard-header h1 {
   font-size: clamp(1.35rem, 2vw, 1.8rem);
 }
@@ -559,6 +612,11 @@ pre {
   .dashboard-header {
     align-items: flex-start;
     flex-direction: column;
+  }
+
+  .dashboard-header-actions {
+    width: 100%;
+    justify-content: space-between;
   }
 }
 

--- a/frontend/src/Homepage.jsx
+++ b/frontend/src/Homepage.jsx
@@ -425,6 +425,7 @@ function Homepage() {
   const [showcaseSaving, setShowcaseSaving] = useState(false);
   const [showcaseGenerating, setShowcaseGenerating] = useState(false);
   const [showcaseError, setShowcaseError] = useState('');
+  const [dashboardViewMode, setDashboardViewMode] = useState('owner');
   const [dashboardMode, setDashboardMode] = useState('private');
   const [dashboardPublicSlug, setDashboardPublicSlug] = useState('');
   const [publicPreviewVersion, setPublicPreviewVersion] = useState(0);
@@ -484,6 +485,7 @@ function Homepage() {
     setShowcaseSaving(false);
     setShowcaseGenerating(false);
     setShowcaseError('');
+    setDashboardViewMode('owner');
     setDashboardMode('private');
     setDashboardPublicSlug('');
     setPublicPreviewVersion(0);
@@ -1040,6 +1042,8 @@ function Homepage() {
     }
     await publishDashboard();
   };
+
+  const isPublicFacingView = dashboardViewMode === 'public';
 
   const handleUpload = async () => {
     if (!file) return;
@@ -1719,6 +1723,12 @@ function Homepage() {
     []
   );
 
+  const visibleNavButtons = useMemo(() => {
+    if (!isPublicFacingView) return navButtons;
+    const allowedInPublic = new Set(['projects', 'skills', 'top']);
+    return navButtons.filter((item) => allowedInPublic.has(item.id));
+  }, [isPublicFacingView, navButtons]);
+
   const reportStats = useMemo(() => {
     const toNumber = (value) => {
       if (value === null || value === undefined) return null;
@@ -1846,6 +1856,14 @@ function Homepage() {
     return asText.length >= 10 ? asText.slice(0, 10) : asText;
   }, []);
 
+  useEffect(() => {
+    if (!isPublicFacingView) return;
+    const allowedViews = new Set(['projects', 'skills', 'top', 'report']);
+    if (!allowedViews.has(view)) {
+      setView('projects');
+    }
+  }, [isPublicFacingView, view]);
+
   if (sessionLoading) {
     return (
       <div className="screen-shell">
@@ -1968,13 +1986,26 @@ function Homepage() {
             <p className="eyebrow">Signed in as</p>
             <h1>{currentUser.display_name || currentUser.email}</h1>
           </div>
-          <button className="ghost-btn" type="button" onClick={handleLogout}>
-            Log Out
-          </button>
+          <div className="dashboard-header-actions">
+            <fieldset className="mode-switch">
+              <legend className="mode-switch-label">Dashboard View</legend>
+              <select
+                className="mode-select"
+                value={dashboardViewMode}
+                onChange={(event) => setDashboardViewMode(event.target.value)}
+              >
+                <option value="owner">Owner</option>
+                <option value="public">Public</option>
+              </select>
+            </fieldset>
+            <button className="ghost-btn" type="button" onClick={handleLogout}>
+              Log Out
+            </button>
+          </div>
         </header>
 
         <nav className="dashboard-nav">
-          {navButtons.map((item) => (
+          {visibleNavButtons.map((item) => (
             <button
               key={item.id}
               type="button"
@@ -2042,19 +2073,23 @@ function Homepage() {
                         )}
                         <div className="card-actions">
                           <button className="primary-btn" type="button" onClick={() => viewProjectDetails(project)}>
-                            View Details
+                            {isPublicFacingView ? 'View Public Details' : 'View Details'}
                           </button>
-                          <button className="secondary-btn" type="button" onClick={() => generateResume(project.id)}>
-                            Generate Resume
-                          </button>
-                          <button
-                            className="secondary-btn"
-                            type="button"
-                            onClick={() => deleteProject(project)}
-                            disabled={deletingProjectId === project.id}
-                          >
-                            {deletingProjectId === project.id ? 'Deleting...' : 'Delete Project'}
-                          </button>
+                          {!isPublicFacingView && (
+                            <>
+                              <button className="secondary-btn" type="button" onClick={() => generateResume(project.id)}>
+                                Generate Resume
+                              </button>
+                              <button
+                                className="secondary-btn"
+                                type="button"
+                                onClick={() => deleteProject(project)}
+                                disabled={deletingProjectId === project.id}
+                              >
+                                {deletingProjectId === project.id ? 'Deleting...' : 'Delete Project'}
+                              </button>
+                            </>
+                          )}
                         </div>
                       </article>
                     );
@@ -2595,6 +2630,12 @@ function Homepage() {
                 <p>Loading project details...</p>
               ) : (
                 <>
+                  {isPublicFacingView && (
+                    <p className="muted">
+                      Public view is active. Edit controls are hidden and only read-only project details are shown.
+                    </p>
+                  )}
+
                   <div className="stack-block">
                     <h3>Analysis Status</h3>
                     {selectedProjectStatus && (
@@ -2612,148 +2653,150 @@ function Homepage() {
                     )}
                   </div>
 
-                  <div className="stack-block">
-                    <h3>Project Thumbnail</h3>
-                    {selectedProjectThumbnail?.loading ? (
-                      <p>Loading thumbnail...</p>
-                    ) : selectedProjectThumbnail?.hasImage ? (
-                      <img
-                        className="project-thumbnail project-thumbnail-detail"
-                        src={selectedProjectThumbnail.imageUrl}
-                        alt={`${selectedProject.name} thumbnail`}
-                      />
-                    ) : (
-                      <div className="project-thumbnail project-thumbnail-placeholder project-thumbnail-detail">
-                        No thumbnail uploaded yet.
-                      </div>
-                    )}
-                    {selectedProjectThumbnail?.error && (
-                      <p className="error-banner inline-error">{selectedProjectThumbnail.error}</p>
-                    )}
-                    <label className="field">
-                      Upload or replace thumbnail
-                      <input
-                        type="file"
-                        accept="image/*"
-                        onChange={(event) => {
-                          setThumbnailActionError('');
-                          setThumbnailUploadFile(event.target.files?.[0] || null);
-                        }}
-                      />
-                    </label>
-                    {thumbnailUploadFile && <p className="muted">Selected image: {thumbnailUploadFile.name}</p>}
-                    <div className="card-actions">
-                      <button
-                        className="primary-btn"
-                        type="button"
-                        onClick={saveProjectThumbnail}
-                        disabled={!thumbnailUploadFile || thumbnailActionProjectId === selectedProject.id}
-                      >
-                        {thumbnailActionProjectId === selectedProject.id ? 'Saving thumbnail...' : 'Save Thumbnail'}
-                      </button>
-                      <button
-                        className="secondary-btn"
-                        type="button"
-                        onClick={removeProjectThumbnail}
-                        disabled={!selectedProjectThumbnail?.hasImage || thumbnailActionProjectId === selectedProject.id}
-                      >
-                        {thumbnailActionProjectId === selectedProject.id ? 'Removing thumbnail...' : 'Remove Thumbnail'}
-                      </button>
-                    </div>
-                    {thumbnailActionError && <p className="error-banner inline-error">{thumbnailActionError}</p>}
-                  </div>
-
-                  <div className="stack-block">
-                    <h3>Key Role</h3>
-                    <label className="field">
-                      Your role in this project
-                      <textarea
-                        value={projectRoleDraft}
-                        maxLength={128}
-                        rows={3}
-                        placeholder="e.g. Technical Lead, Full-Stack Developer"
-                        onChange={(event) => setProjectRoleDraft(event.target.value)}
-                      />
-                    </label>
-                    <p className="muted">
-                      Saved role text is included in resume and portfolio generation for this project.
-                    </p>
-                    <button
-                      className="primary-btn"
-                      type="button"
-                      onClick={saveProjectRole}
-                      disabled={loading || savingProjectRole || !projectRoleChanged}
-                    >
-                      {savingProjectRole ? 'Saving role...' : 'Save Role'}
-                    </button>
-                  </div>
-
-                  <div className="stack-block">
-                    <h3>Portfolio Showcase</h3>
-                    <p className="muted">
-                      The title and summary shown for this project in your portfolio. Generate to create AI-drafted
-                      wording, then edit and save your changes.
-                    </p>
-                    {showcaseError && <p className="error-banner inline-error">{showcaseError}</p>}
-                    {!selectedShowcase ? (
-                      <button
-                        className="secondary-btn"
-                        type="button"
-                        onClick={generateShowcase}
-                        disabled={showcaseGenerating}
-                      >
-                        {showcaseGenerating ? 'Generating...' : 'Generate Showcase Text'}
-                      </button>
-                    ) : (
-                      <>
+                  {!isPublicFacingView && (
+                    <>
+                      <div className="stack-block">
+                        <h3>Project Thumbnail</h3>
+                        {selectedProjectThumbnail?.loading ? (
+                          <p>Loading thumbnail...</p>
+                        ) : selectedProjectThumbnail?.hasImage ? (
+                          <img
+                            className="project-thumbnail project-thumbnail-detail"
+                            src={selectedProjectThumbnail.imageUrl}
+                            alt={`${selectedProject.name} thumbnail`}
+                          />
+                        ) : (
+                          <div className="project-thumbnail project-thumbnail-placeholder project-thumbnail-detail">
+                            No thumbnail uploaded yet.
+                          </div>
+                        )}
+                        {selectedProjectThumbnail?.error && (
+                          <p className="error-banner inline-error">{selectedProjectThumbnail.error}</p>
+                        )}
                         <label className="field">
-                          Title
+                          Upload or replace thumbnail
                           <input
-                            type="text"
-                            value={showcaseDraft.title}
-                            maxLength={200}
-                            placeholder="Showcase title"
-                            onChange={(e) => setShowcaseDraft((prev) => ({ ...prev, title: e.target.value }))}
+                            type="file"
+                            accept="image/*"
+                            onChange={(event) => {
+                              setThumbnailActionError('');
+                              setThumbnailUploadFile(event.target.files?.[0] || null);
+                            }}
                           />
                         </label>
-                        <label className="field">
-                          Summary
-                          <textarea
-                            value={showcaseDraft.summary_text}
-                            rows={5}
-                            placeholder="Portfolio showcase summary"
-                            onChange={(e) => setShowcaseDraft((prev) => ({ ...prev, summary_text: e.target.value }))}
-                          />
-                        </label>
+                        {thumbnailUploadFile && <p className="muted">Selected image: {thumbnailUploadFile.name}</p>}
                         <div className="card-actions">
                           <button
                             className="primary-btn"
                             type="button"
-                            onClick={saveShowcase}
-                            disabled={showcaseSaving || !showcaseChanged}
+                            onClick={saveProjectThumbnail}
+                            disabled={!thumbnailUploadFile || thumbnailActionProjectId === selectedProject.id}
                           >
-                            {showcaseSaving ? 'Saving...' : 'Save Showcase'}
+                            {thumbnailActionProjectId === selectedProject.id ? 'Saving thumbnail...' : 'Save Thumbnail'}
                           </button>
+                          <button
+                            className="secondary-btn"
+                            type="button"
+                            onClick={removeProjectThumbnail}
+                            disabled={!selectedProjectThumbnail?.hasImage || thumbnailActionProjectId === selectedProject.id}
+                          >
+                            {thumbnailActionProjectId === selectedProject.id ? 'Removing thumbnail...' : 'Remove Thumbnail'}
+                          </button>
+                        </div>
+                        {thumbnailActionError && <p className="error-banner inline-error">{thumbnailActionError}</p>}
+                      </div>
+
+                      <div className="stack-block">
+                        <h3>Key Role</h3>
+                        <label className="field">
+                          Your role in this project
+                          <textarea
+                            value={projectRoleDraft}
+                            maxLength={128}
+                            rows={3}
+                            placeholder="e.g. Technical Lead, Full-Stack Developer"
+                            onChange={(event) => setProjectRoleDraft(event.target.value)}
+                          />
+                        </label>
+                        <p className="muted">
+                          Saved role text is included in resume and portfolio generation for this project.
+                        </p>
+                        <button
+                          className="primary-btn"
+                          type="button"
+                          onClick={saveProjectRole}
+                          disabled={loading || savingProjectRole || !projectRoleChanged}
+                        >
+                          {savingProjectRole ? 'Saving role...' : 'Save Role'}
+                        </button>
+                      </div>
+
+                      <div className="stack-block">
+                        <h3>Portfolio Showcase</h3>
+                        <p className="muted">
+                          The title and summary shown for this project in your portfolio. Generate to create AI-drafted
+                          wording, then edit and save your changes.
+                        </p>
+                        {showcaseError && <p className="error-banner inline-error">{showcaseError}</p>}
+                        {!selectedShowcase ? (
                           <button
                             className="secondary-btn"
                             type="button"
                             onClick={generateShowcase}
                             disabled={showcaseGenerating}
                           >
-                            {showcaseGenerating ? 'Regenerating...' : 'Regenerate'}
+                            {showcaseGenerating ? 'Generating...' : 'Generate Showcase Text'}
                           </button>
-                        </div>
-                      </>
-                    )}
-                  </div>
+                        ) : (
+                          <>
+                            <label className="field">
+                              Title
+                              <input
+                                type="text"
+                                value={showcaseDraft.title}
+                                maxLength={200}
+                                placeholder="Showcase title"
+                                onChange={(e) => setShowcaseDraft((prev) => ({ ...prev, title: e.target.value }))}
+                              />
+                            </label>
+                            <label className="field">
+                              Summary
+                              <textarea
+                                value={showcaseDraft.summary_text}
+                                rows={5}
+                                placeholder="Portfolio showcase summary"
+                                onChange={(e) => setShowcaseDraft((prev) => ({ ...prev, summary_text: e.target.value }))}
+                              />
+                            </label>
+                            <div className="card-actions">
+                              <button
+                                className="primary-btn"
+                                type="button"
+                                onClick={saveShowcase}
+                                disabled={showcaseSaving || !showcaseChanged}
+                              >
+                                {showcaseSaving ? 'Saving...' : 'Save Showcase'}
+                              </button>
+                              <button
+                                className="secondary-btn"
+                                type="button"
+                                onClick={generateShowcase}
+                                disabled={showcaseGenerating}
+                              >
+                                {showcaseGenerating ? 'Regenerating...' : 'Regenerate'}
+                              </button>
+                            </div>
+                          </>
+                        )}
+                      </div>
 
-                  <div className="stack-block">
-                    <h3>Evidence of Success</h3>
-                    <p className="muted">
-                      Add metrics, feedback, and evaluation notes for this project. Numeric values (for example
-                      <code> 42 </code>) and JSON values (for example <code>{'{"grade":"A"}'}</code>) are saved as
-                      structured evidence.
-                    </p>
+                      <div className="stack-block">
+                        <h3>Evidence of Success</h3>
+                        <p className="muted">
+                          Add metrics, feedback, and evaluation notes for this project. Numeric values (for example
+                          <code> 42 </code>) and JSON values (for example <code>{'{"grade":"A"}'}</code>) are saved as
+                          structured evidence.
+                        </p>
 
                     <div className="evidence-section">
                       <div className="panel-title-row">
@@ -2922,17 +2965,19 @@ function Homepage() {
                       )}
                     </div>
 
-                    {projectEvidenceError && <p className="error-banner inline-error">{projectEvidenceError}</p>}
+                        {projectEvidenceError && <p className="error-banner inline-error">{projectEvidenceError}</p>}
 
-                    <button
-                      className="primary-btn"
-                      type="button"
-                      onClick={saveProjectEvidence}
-                      disabled={loading || savingProjectEvidence}
-                    >
-                      {savingProjectEvidence ? 'Saving evidence...' : 'Save Evidence'}
-                    </button>
-                  </div>
+                        <button
+                          className="primary-btn"
+                          type="button"
+                          onClick={saveProjectEvidence}
+                          disabled={loading || savingProjectEvidence}
+                        >
+                          {savingProjectEvidence ? 'Saving evidence...' : 'Save Evidence'}
+                        </button>
+                      </div>
+                    </>
+                  )}
 
                   {projectReport && (
                     <div className="stack-block">
@@ -3003,72 +3048,74 @@ function Homepage() {
                     </div>
                   )}
 
-                  <div className="stack-block">
-                    <h3>Resume Editing</h3>
-                    {!activeResumeId ? (
-                      <>
-                        <p className="muted">No resume generated yet. Generate one from the projects list, or:</p>
-                        <button
-                          className="primary-btn"
-                          type="button"
-                          disabled={loading}
-                          onClick={handleGenerateResume}
-                        >
-                          {loading ? 'Generating...' : 'Generate Resume'}
-                        </button>
-                      </>
-                    ) : (
-                      <>
-                        <label className="field">
-                          Summary
-                          <textarea
-                            rows={4}
-                            value={resumeWording.summary_text}
-                            onChange={(e) => setResumeWording((prev) => ({ ...prev, summary_text: e.target.value }))}
-                          />
-                        </label>
+                  {!isPublicFacingView && (
+                    <div className="stack-block">
+                      <h3>Resume Editing</h3>
+                      {!activeResumeId ? (
+                        <>
+                          <p className="muted">No resume generated yet. Generate one from the projects list, or:</p>
+                          <button
+                            className="primary-btn"
+                            type="button"
+                            disabled={loading}
+                            onClick={handleGenerateResume}
+                          >
+                            {loading ? 'Generating...' : 'Generate Resume'}
+                          </button>
+                        </>
+                      ) : (
+                        <>
+                          <label className="field">
+                            Summary
+                            <textarea
+                              rows={4}
+                              value={resumeWording.summary_text}
+                              onChange={(e) => setResumeWording((prev) => ({ ...prev, summary_text: e.target.value }))}
+                            />
+                          </label>
 
-                        {resumeWording.resume_bullets.length > 0 && (
-                          <>
-                            <h4>Bullet Points</h4>
-                            {resumeWording.resume_bullets.map((bullet, index) => (
-                              <label className="field" key={index}>
-                                Bullet {index + 1}
-                                <textarea
-                                  rows={2}
-                                  value={bullet}
-                                  onChange={(e) => {
-                                    const updated = [...resumeWording.resume_bullets];
-                                    updated[index] = e.target.value;
-                                    setResumeWording((prev) => ({ ...prev, resume_bullets: updated }));
-                                  }}
-                                />
-                              </label>
-                            ))}
-                          </>
-                        )}
+                          {resumeWording.resume_bullets.length > 0 && (
+                            <>
+                              <h4>Bullet Points</h4>
+                              {resumeWording.resume_bullets.map((bullet, index) => (
+                                <label className="field" key={index}>
+                                  Bullet {index + 1}
+                                  <textarea
+                                    rows={2}
+                                    value={bullet}
+                                    onChange={(e) => {
+                                      const updated = [...resumeWording.resume_bullets];
+                                      updated[index] = e.target.value;
+                                      setResumeWording((prev) => ({ ...prev, resume_bullets: updated }));
+                                    }}
+                                  />
+                                </label>
+                              ))}
+                            </>
+                          )}
 
-                        <button
-                          className="primary-btn"
-                          type="button"
-                          onClick={saveResumeWording}
-                          disabled={savingResume}
-                        >
-                          {savingResume ? 'Saving...' : 'Save Resume Edits'}
-                        </button>
+                          <button
+                            className="primary-btn"
+                            type="button"
+                            onClick={saveResumeWording}
+                            disabled={savingResume}
+                          >
+                            {savingResume ? 'Saving...' : 'Save Resume Edits'}
+                          </button>
 
-                        <button
-                          className="secondary-btn"
-                          type="button"
-                          onClick={() => window.open(`${API_BASE_URL}/resume/${activeResumeId}/pdf`, '_blank', 'noopener,noreferrer')}
-                        >
-                          Download Resume PDF
-                        </button>
+                          <button
+                            className="secondary-btn"
+                            type="button"
+                            onClick={() => window.open(`${API_BASE_URL}/resume/${activeResumeId}/pdf`, '_blank', 'noopener,noreferrer')}
+                          >
+                            Download Resume PDF
+                          </button>
 
-                        {resumeSaveStatus && <p className="muted">{resumeSaveStatus}</p>}
-                      </>
-                    )}
-                  </div>
+                          {resumeSaveStatus && <p className="muted">{resumeSaveStatus}</p>}
+                        </>
+                      )}
+                    </div>
+                  )}
                 </>
               )}
             </section>

--- a/src/api/app.py
+++ b/src/api/app.py
@@ -293,6 +293,71 @@ def _assert_portfolio_owned_by(conn, *, portfolio_id: str, user_id: str) -> None
     if owner != str(user_id):
         raise HTTPException(status_code=403, detail="Portfolio does not belong to the authenticated user")
 
+
+def _assert_dashboard_private_for_portfolio(conn, portfolio_id: Optional[str]) -> None:
+    if not portfolio_id:
+        return
+    dashboard = ensure_portfolio_dashboard(conn, str(portfolio_id))
+    if dashboard.get("mode") == DASHBOARD_MODE_PUBLIC:
+        raise HTTPException(
+            status_code=409,
+            detail="Dashboard is in public mode. Switch to private mode before editing dashboard customizations.",
+        )
+
+
+def _portfolio_id_for_project(conn, project_id: str) -> Optional[str]:
+    value = conn.execute(
+        text("SELECT portfolio_id FROM projects WHERE id = :pid"),
+        {"pid": project_id},
+    ).scalar()
+    return str(value) if value else None
+
+
+def _portfolio_id_for_resume(conn, resume_id: str) -> Optional[str]:
+    value = conn.execute(
+        text(
+            """
+            SELECT p.portfolio_id
+            FROM resume_items r
+            JOIN projects p ON p.id = r.project_id
+            WHERE r.id = :rid
+            """
+        ),
+        {"rid": resume_id},
+    ).scalar()
+    return str(value) if value else None
+
+
+def _portfolio_id_for_showcase(conn, showcase_id: str) -> Optional[str]:
+    value = conn.execute(
+        text(
+            """
+            SELECT p.portfolio_id
+            FROM portfolio_showcases s
+            JOIN projects p ON p.id = s.project_id
+            WHERE s.id = :sid
+            """
+        ),
+        {"sid": showcase_id},
+    ).scalar()
+    return str(value) if value else None
+
+
+def _default_portfolio_id_for_user(conn, user_id: str) -> Optional[str]:
+    value = conn.execute(
+        text(
+            """
+            SELECT id
+            FROM portfolios
+            WHERE user_id = :uid
+            ORDER BY CASE WHEN name = 'default' THEN 0 ELSE 1 END, created_at ASC
+            LIMIT 1
+            """
+        ),
+        {"uid": user_id},
+    ).scalar()
+    return str(value) if value else None
+
 def _auth_user_payload(user_id: str, email: str, display_name: Optional[str], portfolio_id: Optional[str]) -> Dict[str, Any]:
     return {
         "user_id": str(user_id),
@@ -963,6 +1028,8 @@ def get_config(user_id: str):
 def put_config(user_id: str, payload: UserConfigIn):
     engine = get_engine()
     with engine.begin() as conn:
+        portfolio_id = _default_portfolio_id_for_user(conn, user_id)
+        _assert_dashboard_private_for_portfolio(conn, portfolio_id)
         cfg = put_user_config(conn, user_id, payload.config or {})
     return {"user_id": user_id, "config": cfg}
 
@@ -971,6 +1038,8 @@ def put_config(user_id: str, payload: UserConfigIn):
 def patch_config(user_id: str, patch: Dict[str, Any] = Body(default_factory=dict)):
     engine = get_engine()
     with engine.begin() as conn:
+        portfolio_id = _default_portfolio_id_for_user(conn, user_id)
+        _assert_dashboard_private_for_portfolio(conn, portfolio_id)
         cfg = merge_user_config(conn, user_id, patch or {})
     return {"user_id": user_id, "config": cfg}
 
@@ -1484,12 +1553,14 @@ def update_project(project_id: str, payload: ProjectUpdateIn):
     engine = get_engine()
     with engine.begin() as conn:
         row = conn.execute(
-            text("SELECT 1 FROM projects WHERE id = :pid"),
+            text("SELECT portfolio_id FROM projects WHERE id = :pid"),
             {"pid": project_id}
-        ).scalar()
+        ).mappings().first()
 
         if not row:
             raise HTTPException(status_code=404, detail="Project not found")
+
+        _assert_dashboard_private_for_portfolio(conn, row.get("portfolio_id"))
 
         updates = payload.model_dump(exclude_unset=True)
         if not updates:
@@ -1894,6 +1965,12 @@ def generate_resume(payload: ResumeGenerateIn):
     Returns the created resume_id and its stored content_json.
     """
     engine = get_engine()
+    with engine.begin() as conn:
+        portfolio_id = _portfolio_id_for_project(conn, payload.project_id)
+        if not portfolio_id:
+            raise HTTPException(status_code=404, detail="Project not found")
+        _assert_dashboard_private_for_portfolio(conn, portfolio_id)
+
     try:
         out = generate_resume_item(
             engine=engine,
@@ -1946,6 +2023,11 @@ def edit_resume(resume_id: str, body: ResumeEditRequest):
     engine = get_engine()
 
     with engine.begin() as conn:
+        portfolio_id = _portfolio_id_for_resume(conn, resume_id)
+        if not portfolio_id:
+            raise HTTPException(status_code=404, detail="Resume not found")
+        _assert_dashboard_private_for_portfolio(conn, portfolio_id)
+
         row = conn.execute(
             text("SELECT content_json FROM resume_items WHERE id = :id"),
             {"id": resume_id},
@@ -2038,6 +2120,9 @@ def generate_portfolio(payload: PortfolioGenerateIn):
     If persist=true, creates portfolio_showcases rows (output artifacts) per summarized project.
     """
     engine = get_engine()
+    with engine.begin() as conn:
+        _assert_dashboard_private_for_portfolio(conn, payload.portfolio_id)
+
     try:
         out = generate_portfolio_top_summaries(
             engine=engine,
@@ -2056,6 +2141,12 @@ def generate_project_showcase_endpoint(project_id: str):
     Unlike /portfolio/generate, this only affects the one project.
     """
     engine = get_engine()
+    with engine.begin() as conn:
+        portfolio_id = _portfolio_id_for_project(conn, project_id)
+        if not portfolio_id:
+            raise HTTPException(status_code=404, detail="Project not found")
+        _assert_dashboard_private_for_portfolio(conn, portfolio_id)
+
     try:
         return generate_project_showcase(engine=engine, project_id=project_id)
     except KeyError:
@@ -2066,6 +2157,11 @@ def edit_portfolio_showcase(showcase_id: str, body: PortfolioEditRequest):
     engine = get_engine()
 
     with engine.begin() as conn:
+        portfolio_id = _portfolio_id_for_showcase(conn, showcase_id)
+        if not portfolio_id:
+            raise HTTPException(status_code=404, detail="Showcase not found")
+        _assert_dashboard_private_for_portfolio(conn, portfolio_id)
+
         row = conn.execute(
             text("SELECT content_json FROM portfolio_showcases WHERE id = :id"),
             {"id": showcase_id},
@@ -2779,11 +2875,13 @@ async def set_project_image(
 ):
     # 1. Early FK check
     exists = db.execute(
-        text("SELECT 1 FROM projects WHERE id = :pid"),
+        text("SELECT portfolio_id FROM projects WHERE id = :pid"),
         {"pid": str(project_id)},
-    ).scalar()
+    ).mappings().first()
     if not exists:
         raise HTTPException(status_code=404, detail="Project not found")
+
+    _assert_dashboard_private_for_portfolio(db, exists.get("portfolio_id"))
 
     # 2. Read file
     data = await file.read()
@@ -2939,6 +3037,11 @@ def get_project_image(project_id: str):
 def delete_project_image(project_id: str):
     engine = get_engine()
     with engine.begin() as conn:
+        portfolio_id = _portfolio_id_for_project(conn, project_id)
+        if not portfolio_id:
+            raise HTTPException(status_code=404, detail="Project not found")
+        _assert_dashboard_private_for_portfolio(conn, portfolio_id)
+
         row = conn.execute(
             text(
                 """

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -539,14 +539,23 @@ def test_public_dashboard_filter_validation_and_application(client, engine):
     assert [p["id"] for p in body["dashboard"]["projects"]] == [p1]
     assert all((event.get("skill") or "").casefold() == "python" for event in body["dashboard"]["skills_timeline"])
 
+    r_filtered_again = client.get(f"/public/portfolio/{slug}?project_ids={p1}&skills=python")
+    assert r_filtered_again.status_code == 200
+    body_again = r_filtered_again.json()
+    assert [p["id"] for p in body_again["dashboard"]["projects"]] == [p["id"] for p in body["dashboard"]["projects"]]
+    assert [p.get("project_id") for p in body_again["dashboard"]["top_projects"]] == [
+        p.get("project_id") for p in body["dashboard"]["top_projects"]
+    ]
 
-def test_dashboard_public_mode_still_allows_dashboard_mutations(client, engine):
+
+def test_dashboard_public_mode_blocks_dashboard_mutations(client, engine):
     account = _register_user(client, email="dashboard-locks@example.com")
     headers = {"Authorization": f"Bearer {account['token']}"}
 
     project_id = _u()
     snapshot_id = _u()
     showcase_id = _u()
+    resume_id = _u()
 
     with engine.begin() as conn:
         conn.execute(
@@ -571,24 +580,46 @@ def test_dashboard_public_mode_still_allows_dashboard_mutations(client, engine):
             ),
             {"id": showcase_id, "pid": project_id},
         )
+        conn.execute(
+            text(
+                """
+                INSERT INTO resume_items (id, project_id, content_json)
+                VALUES (:id, :pid, '{"summary_text":"old","resume_bullets":["b1"]}'::jsonb)
+                """
+            ),
+            {"id": resume_id, "pid": project_id},
+        )
 
     r_publish = client.post(f"/portfolio/{account['portfolio_id']}/dashboard/publish", headers=headers)
     assert r_publish.status_code == 200
 
     r_cfg = client.patch(f"/users/{account['user_id']}/config", json={"highlights": {"skills": ["python"]}})
-    assert r_cfg.status_code == 200
+    assert r_cfg.status_code == 409
+    assert "public mode" in r_cfg.text.lower()
 
     r_generate_pf = client.post("/portfolio/generate", json={"portfolio_id": account["portfolio_id"]})
-    assert r_generate_pf.status_code == 200
+    assert r_generate_pf.status_code == 409
 
     r_generate_showcase = client.post(f"/projects/{project_id}/showcase/generate")
-    assert r_generate_showcase.status_code == 200
+    assert r_generate_showcase.status_code == 409
+
+    r_edit_project = client.patch(
+        f"/projects/{project_id}",
+        json={"user_role": "Lead Developer"},
+    )
+    assert r_edit_project.status_code == 409
 
     r_edit_showcase = client.post(
         f"/portfolio/{showcase_id}/edit",
         json={"title": "new title"},
     )
-    assert r_edit_showcase.status_code == 200
+    assert r_edit_showcase.status_code == 409
+
+    r_edit_resume = client.post(
+        f"/resume/{resume_id}/edit",
+        json={"summary_text": "new summary"},
+    )
+    assert r_edit_resume.status_code == 409
 
 
 def test_authenticated_user_scope_rejects_mismatched_user_id(client):


### PR DESCRIPTION
## 📝 Description

Adds a **Public/Owner view toggle** to the portfolio dashboard that controls what the user can see and do. In **Public mode**, all customization and edit actions are hidden in the UI and blocked at the API layer with a `409` response. In **Owner mode**, full editing capabilities remain available. Covers issue #297.

**Closes:** #297

---

## 🔧 Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

Tested manually by toggling the dashboard header between Owner and Public mode and confirming edit controls appear and disappear as expected. API endpoints were verified to return `409` when called in Public mode.

> ⚠️ **Note:** Automated pytest run is currently blocked by an environment conflict:
> ```
> ImportError: cannot import name 'InvalidGitRepositoryError' from 'git'
> ```
> Likely caused by the wrong `git` package shadowing `GitPython` in `.venv`. Tests are written and structurally correct — resolving the venv conflict will allow full verification.

Once the venv issue is resolved, run:

pytest test_api.py::test_dashboard_public_mode_blocks_dashboard_mutations
pytest test_api.py::test_public_dashboard_filter_validation_and_application -v

- [x] Toggle Owner → Public hides all edit/customization UI
- [x] Toggle Public → Owner restores all edit/customization UI
- [x] Non-allowed tabs in Public mode redirect automatically
- [x] `409` returned on mutation endpoints (config patch, portfolio generate, showcase generate, project patch, showcase edit, resume edit) when dashboard is public
- [x] Filtered results return deterministically across repeated requests
- [ ] Automated tests passing locally *(blocked — see note above)*

---

## ✓ Checklist
- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [ ] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

<!-- Add Owner vs Public mode toggle screenshot here -->
<!-- Add hidden edit controls in Public mode screenshot here -->

</details>
```

