### PR TITLE
Resume Data Contract: Skills Bucketing, Evidence Normalization & Resume Payload [PR# 3/4] [FIX]

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -3338,3 +3338,123 @@ def _award_row_to_out(row) -> Dict[str, Any]:
         "created_at": r["created_at"].isoformat() if hasattr(r["created_at"], "isoformat") else str(r["created_at"]),
         "updated_at": r["updated_at"].isoformat() if hasattr(r["updated_at"], "isoformat") else str(r["updated_at"]),
     }
+
+# ---------------------------------------------------------------------------
+# Resume composite payload
+# GET /users/{user_id}/resume-payload
+# ---------------------------------------------------------------------------
+
+@app.get("/users/{user_id}/resume-payload")
+def get_resume_payload(user_id: str, db: Session = Depends(get_db)):
+    """
+    Returns the full one-page resume data contract:
+      - education entries
+      - awards entries
+      - bucketed skills (derived from latest analysis per project)
+      - normalized contribution/impact evidence per project
+    """
+    # 1. Verify user exists
+    row = db.execute(text("SELECT 1 FROM users WHERE id = :uid"), {"uid": user_id}).scalar()
+    if not row:
+        raise HTTPException(status_code=404, detail="User not found")
+
+    # 2. Education
+    edu_rows = db.execute(
+        text(
+            """
+            SELECT id, user_id, institution, degree, field_of_study,
+                   start_year, end_year, is_current, description,
+                   created_at, updated_at
+            FROM education_entries WHERE user_id = :uid
+            ORDER BY start_year DESC NULLS LAST, created_at DESC
+            """
+        ),
+        {"uid": user_id},
+    ).mappings().all()
+
+    # 3. Awards
+    award_rows = db.execute(
+        text(
+            """
+            SELECT id, user_id, title, issuer, awarded_year, description,
+                   created_at, updated_at
+            FROM award_entries WHERE user_id = :uid
+            ORDER BY awarded_year DESC NULLS LAST, created_at DESC
+            """
+        ),
+        {"uid": user_id},
+    ).mappings().all()
+
+    # 4. Projects with their evidence payloads
+    project_rows = db.execute(
+        text(
+            """
+            SELECT
+                p.id          AS project_id,
+                p.name        AS project_name,
+                p.user_role,
+                p.evidence_json
+            FROM projects p
+            JOIN portfolios pf ON pf.id = p.portfolio_id
+            WHERE pf.user_id = :uid
+            ORDER BY p.created_at DESC
+            """
+        ),
+        {"uid": user_id},
+    ).mappings().all()
+
+    # 5. Skills via normalized tables: latest analysis per project → analysis_skills → skills
+    skill_rows = db.execute(
+        text(
+            """
+            SELECT
+                p.id        AS project_id,
+                sk.skill_name,
+                ask.confidence
+            FROM projects p
+            JOIN portfolios pf ON pf.id = p.portfolio_id
+            JOIN snapshots sn ON sn.project_id = p.id
+            JOIN LATERAL (
+                SELECT id
+                FROM analyses
+                WHERE snapshot_id IN (
+                    SELECT id FROM snapshots WHERE project_id = p.id
+                )
+                ORDER BY created_at DESC
+                LIMIT 1
+            ) latest_a ON true
+            JOIN analysis_skills ask ON ask.analysis_id = latest_a.id
+            JOIN skills sk ON sk.id = ask.skill_id
+            WHERE pf.user_id = :uid
+            """
+        ),
+        {"uid": user_id},
+    ).mappings().all()
+
+    # Group skills by project_id for O(1) lookup below
+    from collections import defaultdict
+    skills_by_project: Dict[str, list] = defaultdict(list)
+    for sr in skill_rows:
+        skills_by_project[str(sr["project_id"])].append(sr)
+
+    projects_out = []
+    for pr in project_rows:
+        pid = str(pr["project_id"])
+        evidence_json = pr.get("evidence_json") or {}
+        if isinstance(evidence_json, str):
+            evidence_json = json.loads(evidence_json)
+
+        projects_out.append({
+            "project_id": pid,
+            "project_name": pr.get("project_name"),
+            "user_role": pr.get("user_role"),
+            "skills": _bucket_skills_from_rows(skills_by_project[pid]),
+            "evidence": _normalize_evidence(evidence_json),
+        })
+
+    return {
+        "user_id": user_id,
+        "education": [_education_row_to_out(r) for r in edu_rows],
+        "awards": [_award_row_to_out(r) for r in award_rows],
+        "projects": projects_out,
+    }

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2099,6 +2099,124 @@ def test_portfolio_showcase_upsert_logic(engine):
             final_content = json.loads(final_content)
         assert final_content["description"] == "Updated Version"
 
+
+from src.api.app import bucket_skill_expertise, _normalize_evidence, _bucket_skills_from_rows
+
+
+# ---------------------------------------------------------------------------
+# Skill expertise bucketing  (pure unit tests — no DB needed)
+# ---------------------------------------------------------------------------
+
+def test_bucket_skill_expertise_expert():
+    assert bucket_skill_expertise(0.80) == "expert"
+    assert bucket_skill_expertise(1.00) == "expert"
+    assert bucket_skill_expertise(0.95) == "expert"
+
+
+def test_bucket_skill_expertise_proficient():
+    assert bucket_skill_expertise(0.55) == "proficient"
+    assert bucket_skill_expertise(0.70) == "proficient"
+    assert bucket_skill_expertise(0.799) == "proficient"
+
+
+def test_bucket_skill_expertise_familiar():
+    assert bucket_skill_expertise(0.30) == "familiar"
+    assert bucket_skill_expertise(0.45) == "familiar"
+    assert bucket_skill_expertise(0.549) == "familiar"
+
+
+def test_bucket_skill_expertise_exposure():
+    assert bucket_skill_expertise(0.00) == "exposure"
+    assert bucket_skill_expertise(0.10) == "exposure"
+    assert bucket_skill_expertise(0.299) == "exposure"
+
+
+def test_bucket_skill_expertise_boundary_exact():
+    # Boundaries must be deterministic and inclusive at the threshold
+    assert bucket_skill_expertise(0.80) == "expert"
+    assert bucket_skill_expertise(0.55) == "proficient"
+    assert bucket_skill_expertise(0.30) == "familiar"
+
+
+def test_bucket_skill_expertise_invalid_range():
+    import pytest
+    with pytest.raises(ValueError):
+        bucket_skill_expertise(1.01)
+    with pytest.raises(ValueError):
+        bucket_skill_expertise(-0.01)
+
+
+def test_bucket_skill_expertise_invalid_type():
+    import pytest
+    with pytest.raises((ValueError, TypeError)):
+        bucket_skill_expertise("high")
+
+
+# ---------------------------------------------------------------------------
+# Evidence normalisation  (pure unit tests)
+# ---------------------------------------------------------------------------
+
+def test_normalize_evidence_empty():
+    result = _normalize_evidence(None)
+    assert result == {"contributions": [], "impact": [], "extra": {}}
+
+
+def test_normalize_evidence_full():
+    raw = {
+        "contributions": ["Designed API", "Led migration"],
+        "impact": ["Reduced latency by 30%"],
+        "custom_field": "preserved",
+    }
+    result = _normalize_evidence(raw)
+    assert result["contributions"] == ["Designed API", "Led migration"]
+    assert result["impact"] == ["Reduced latency by 30%"]
+    assert result["extra"]["custom_field"] == "preserved"
+
+
+def test_normalize_evidence_scalar_coercion():
+    # Scalars should be coerced to single-element lists
+    raw = {"contributions": "Single contribution", "impact": "Single impact"}
+    result = _normalize_evidence(raw)
+    assert result["contributions"] == ["Single contribution"]
+    assert result["impact"] == ["Single impact"]
+
+
+def test_normalize_evidence_missing_keys():
+    result = _normalize_evidence({"impact": ["shipped feature"]})
+    assert result["contributions"] == []
+    assert result["impact"] == ["shipped feature"]
+
+
+# ---------------------------------------------------------------------------
+# Bucketed skill extraction from normalized analysis_skills rows
+# ---------------------------------------------------------------------------
+
+def test_bucket_skills_from_rows_sorted():
+    rows = [
+        {"skill_name": "Python", "confidence": 0.60},
+        {"skill_name": "Rust",   "confidence": 0.90},
+        {"skill_name": "Bash",   "confidence": 0.20},
+    ]
+    result = _bucket_skills_from_rows(rows)
+    assert result[0]["name"] == "Rust"
+    assert result[0]["expertise"] == "expert"
+    assert result[1]["name"] == "Python"
+    assert result[1]["expertise"] == "proficient"
+    assert result[2]["name"] == "Bash"
+    assert result[2]["expertise"] == "exposure"
+
+
+def test_bucket_skills_from_rows_empty():
+    assert _bucket_skills_from_rows([]) == []
+
+
+def test_bucket_skills_from_rows_null_confidence():
+    # None confidence should default to 0.0 → exposure
+    rows = [{"skill_name": "Go", "confidence": None}]
+    result = _bucket_skills_from_rows(rows)
+    assert result[0]["expertise"] == "exposure"
+
+
 # ---------------------------------------------------------------------------
 # Education CRUD  (integration tests)
 # ---------------------------------------------------------------------------
@@ -2249,3 +2367,75 @@ def test_awards_delete_wrong_user_returns_404(client, engine):
 
     r2 = client.delete(f"/users/{info_b['user_id']}/awards/{entry_id}")
     assert r2.status_code == 404
+
+
+# ---------------------------------------------------------------------------
+# Resume composite payload
+# ---------------------------------------------------------------------------
+
+def test_resume_payload_shape(client, engine):
+    info = _register_user(client, email="resume_payload@example.com")
+    user_id = info["user_id"]
+
+    # Seed education + award
+    client.post(
+        f"/users/{user_id}/education",
+        json={"institution": "State University", "degree": "B.Sc.", "start_year": 2019, "end_year": 2023},
+    )
+    client.post(
+        f"/users/{user_id}/awards",
+        json={"title": "Dean's List", "awarded_year": 2021},
+    )
+
+    r = client.get(f"/users/{user_id}/resume-payload")
+    assert r.status_code == 200
+    payload = r.json()
+
+    # Top-level keys
+    assert "user_id" in payload
+    assert "education" in payload
+    assert "awards" in payload
+    assert "projects" in payload
+
+    # Education present
+    assert any(e["institution"] == "State University" for e in payload["education"])
+
+    # Award present
+    assert any(a["title"] == "Dean's List" for a in payload["awards"])
+
+    # Projects list is always an array
+    assert isinstance(payload["projects"], list)
+
+
+def test_resume_payload_project_evidence_schema(client, engine):
+    """Each project in the payload must have stable evidence/skills keys."""
+    info = _register_user(client, email="resume_proj@example.com")
+    user_id = info["user_id"]
+    portfolio_id = info["portfolio_id"]
+
+    # Insert a project directly for speed
+    project_id = _u()
+    with engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO projects (id, portfolio_id, name) VALUES (:id, :pf, 'TestProj')"),
+            {"id": project_id, "pf": portfolio_id},
+        )
+
+    r = client.get(f"/users/{user_id}/resume-payload")
+    assert r.status_code == 200
+    projects = r.json()["projects"]
+    assert any(p["project_id"] == project_id for p in projects)
+
+    for p in projects:
+        assert "skills" in p
+        assert "evidence" in p
+        assert isinstance(p["skills"], list)
+        evidence = p["evidence"]
+        assert "contributions" in evidence
+        assert "impact" in evidence
+        assert "extra" in evidence
+
+
+def test_resume_payload_unknown_user_returns_404(client):
+    r = client.get(f"/users/{_u()}/resume-payload")
+    assert r.status_code == 404


### PR DESCRIPTION
## 📝 Description

Adds deterministic skill expertise bucketing, evidence normalization, and the composite resume payload endpoint. The `GET /users/{user_id}/resume-payload` endpoint combines education, awards, bucketed skills, and normalized contribution/impact evidence into a single stable API shape ready for one-page resume rendering. Built on top of the tables and CRUD endpoints introduced in PRs 1/4 and 2/4.

**Closes (once all 4 PRs are merged):** #287

---
## 🔧 Type of Change
- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---
## 🧪 Testing

Tested both manually via curl and automatically via pytest.

**Manual steps:**
- [ ] Register a user and add education + award entries (from PR 2/4)
- [ ] Hit `GET /users/{user_id}/resume-payload` and confirm response contains `education`, `awards`, and `projects` arrays
- [ ] Confirm each project in `projects` has `skills` (with `name`, `probability`, `expertise`) and `evidence` (with `contributions`, `impact`, `extra`)
- [ ] Confirm `GET /users/{unknown_id}/resume-payload` returns 404

**Automated tests added:**
- [ ] `test_bucket_skill_expertise_expert`
- [ ] `test_bucket_skill_expertise_proficient`
- [ ] `test_bucket_skill_expertise_familiar`
- [ ] `test_bucket_skill_expertise_exposure`
- [ ] `test_bucket_skill_expertise_boundary_exact`
- [ ] `test_bucket_skill_expertise_invalid_range`
- [ ] `test_bucket_skill_expertise_invalid_type`
- [ ] `test_normalize_evidence_empty`
- [ ] `test_normalize_evidence_full`
- [ ] `test_normalize_evidence_scalar_coercion`
- [ ] `test_normalize_evidence_missing_keys`
- [ ] `test_bucket_skills_from_rows_sorted`
- [ ] `test_bucket_skills_from_rows_empty`
- [ ] `test_bucket_skills_from_rows_null_confidence`
- [ ] `test_resume_payload_shape`
- [ ] `test_resume_payload_project_evidence_schema`
- [ ] `test_resume_payload_unknown_user_returns_404`

---
## ✓ Checklist
- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---
## 📸 Screenshots

N/A — backend only, no UI changes in this PR.