### PR TITLE
Add year range validation to Education and Awards forms

### DIFF
--- a/frontend/src/Homepage.jsx
+++ b/frontend/src/Homepage.jsx
@@ -1762,7 +1762,7 @@ function Homepage() {
   const [eduForm, setEduForm] = useState({});
   const [awardForm, setAwardForm] = useState({});
   const [eduTouched, setEduTouched] = useState({ start_year: false, end_year: false });
-  const [awdTouched, setAwdTouched] = useState({ year: false });
+  const [awardTouched, setAwardTouched] = useState({ year: false });
 
   const EMPTY_EDU = { institution: '', degree: '', field_of_study: '', start_year: '', end_year: '', is_current: false, description: '' };
   const EMPTY_AWARD = { title: '', issuer: '', awarded_year: '', description: '' };
@@ -1786,9 +1786,9 @@ function Homepage() {
     if (view === 'resume') fetchResumePayload();
   }, [view, fetchResumePayload]);
 
-  const startAddEdu = () => { setEduForm(EMPTY_EDU); setEditingEduId('new'); };
-  const startEditEdu = (entry) => { setEduForm({ ...entry, start_year: entry.start_year || '', end_year: entry.end_year || '' }); setEditingEduId(entry.id); };
-  const cancelEdu = () => {setEditingEduId(null); setEduTouched({})};
+  const startAddEdu = () => { setEduForm(EMPTY_EDU); setEditingEduId('new'); setEduTouched({}); };
+  const startEditEdu = (entry) => { setEduForm({ ...entry, start_year: entry.start_year || '', end_year: entry.end_year || '' }); setEditingEduId(entry.id); setEduTouched({}); };
+  const cancelEdu = () => {setEditingEduId(null); setEduTouched({});};
 
   const saveEdu = async () => {
     setResumeSaving(true);
@@ -1830,9 +1830,9 @@ function Homepage() {
     }
   };
 
-  const startAddAward = () => { setAwardForm(EMPTY_AWARD); setEditingAwardId('new'); };
-  const startEditAward = (entry) => { setAwardForm({ ...entry, awarded_year: entry.awarded_year || '' }); setEditingAwardId(entry.id); };
-  const cancelAward = () => {setEditingAwardId(null); setAwdTouched({})};
+  const startAddAward = () => { setAwardForm(EMPTY_AWARD); setEditingAwardId('new'); setAwardTouched({}); };
+  const startEditAward = (entry) => { setAwardForm({ ...entry, awarded_year: entry.awarded_year || '' }); setEditingAwardId(entry.id); setAwardTouched({}); };
+  const cancelAward = () => {setEditingAwardId(null); setAwardTouched({})};
 
   const saveAward = async () => {
     setResumeSaving(true);
@@ -1850,7 +1850,7 @@ function Homepage() {
       }
       setEditingAwardId(null);
       await fetchResumePayload();
-      setAwdTouched({});
+      setAwardTouched({});
     } catch (err) {
       setDashboardError(err.message || 'Failed to save award.');
     } finally {
@@ -3413,7 +3413,7 @@ function Homepage() {
                         <div className="summary-grid">
                           <label className="field">Title *<input value={awardForm.title || ''} onChange={(e) => setAwardForm((f) => ({ ...f, title: e.target.value }))} placeholder="e.g. Dean's List" /></label>
                           <label className="field">Issuer<input value={awardForm.issuer || ''} onChange={(e) => setAwardForm((f) => ({ ...f, issuer: e.target.value }))} placeholder="e.g. MIT" /></label>
-                          <div style={{position: 'relative'}}><label className="field">Year<input type="number" value={awardForm.awarded_year || ''} onChange={(e) => setAwardForm((f) => ({ ...f, awarded_year: e.target.value }))} onBlur={() => setAwdTouched({ ...awdTouched, year: true })} placeholder="2022" min={1900} max={new Date().getFullYear()} /></label>{awdTouched.year && getAwardYearError(awardForm.awarded_year) && <span style={{ color: 'red', fontSize: '0.78em', position: 'absolute' }}>{getAwardYearError(awardForm.awarded_year)}</span>}</div>
+                          <div style={{position: 'relative'}}><label className="field">Year<input type="number" value={awardForm.awarded_year || ''} onChange={(e) => setAwardForm((f) => ({ ...f, awarded_year: e.target.value }))} onBlur={() => setAwardTouched({ ...awardTouched, year: true })} placeholder="2022" min={1900} max={new Date().getFullYear()} /></label>{awardTouched.year && getAwardYearError(awardForm.awarded_year) && <span style={{ color: 'red', fontSize: '0.78em', position: 'absolute' }}>{getAwardYearError(awardForm.awarded_year)}</span>}</div>
                         </div>
                         <label className="field">Description<textarea value={awardForm.description || ''} onChange={(e) => setAwardForm((f) => ({ ...f, description: e.target.value }))} rows={2} /></label>
                         <div style={{ display: 'flex', gap: '8px' }}>
@@ -3429,7 +3429,7 @@ function Homepage() {
                           <div className="summary-grid">
                             <label className="field">Title *<input value={awardForm.title || ''} onChange={(e) => setAwardForm((f) => ({ ...f, title: e.target.value }))} /></label>
                             <label className="field">Issuer<input value={awardForm.issuer || ''} onChange={(e) => setAwardForm((f) => ({ ...f, issuer: e.target.value }))} /></label>
-                            <div style={{position: 'relative'}}><label className="field">Year<input type="number" value={awardForm.awarded_year || ''} onChange={(e) => setAwardForm((f) => ({ ...f, awarded_year: e.target.value }))} onBlur={() => setAwdTouched({ ...awdTouched, year: true })} min={1900} max={new Date().getFullYear()} /></label>{awdTouched.year && getAwardYearError(awardForm.awarded_year) && <span style={{ color: 'red', fontSize: '0.78em', position: 'absolute' }}>{getAwardYearError(awardForm.awarded_year)}</span>}</div>
+                            <div style={{position: 'relative'}}><label className="field">Year<input type="number" value={awardForm.awarded_year || ''} onChange={(e) => setAwardForm((f) => ({ ...f, awarded_year: e.target.value }))} onBlur={() => setAwardTouched({ ...awardTouched, year: true })} min={1900} max={new Date().getFullYear()} /></label>{awardTouched.year && getAwardYearError(awardForm.awarded_year) && <span style={{ color: 'red', fontSize: '0.78em', position: 'absolute' }}>{getAwardYearError(awardForm.awarded_year)}</span>}</div>
                           </div>
                           <label className="field">Description<textarea value={awardForm.description || ''} onChange={(e) => setAwardForm((f) => ({ ...f, description: e.target.value }))} rows={2} /></label>
                           <div style={{ display: 'flex', gap: '8px' }}>


### PR DESCRIPTION
## 📝 Description
> Please include a summary of the change and which issue is fixed.  
> Include relevant motivation and context.  
> List any dependencies that are required for this change.

Introduces year input validation to the Awards & Education sections of the resume form. Previously, these fields had no validation at all — users could enter any value and save it. This PR adds both the validation logic and the UX controls around it.

**What's new:**
- Added `getEduYearErrors` and `getAwardYearError` helper functions that validate year inputs against a defined range (`YEAR_MIN = 1900` to current year, with a +10 year offset allowed for expected graduation dates on education end years).
- The Save button is now disabled whenever any year field contains an invalid value, making it visually clear the form cannot be submitted.
- Inline red error messages appear beneath invalid year fields, but only after the user has clicked away (`onBlur`) — so errors don't fire on the first keystroke while the user is still typing.
- Added `eduTouched` and `awardTouched` state to track which fields have been interacted with. These reset whenever a form is opened, edited, or cancelled, so stale error states never appear.
- Validation and UX behaviour is consistent across both the "new entry" and "edit existing entry" form variants for Education and Awards.

**Closes:** #321 

---

## 🔧 Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [ ] ✅ Test added/updated ** tests coming in subsequent PR where I'll start our E2E testing setup (different scope so different PR)
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

> Please describe how you tested this PR (both manually and with tests).  
> Provide instructions so we can reproduce.

**Manual testing steps:**

- [x] Open the Education form and type an invalid start year (e.g. `1800`) — confirm no error appears while typing, but error appears after clicking away
- [x] Confirm the Save button is greyed out while the year is invalid, and re-enables once corrected
- [x] Repeat the above for the End Year field on Education (including the "cannot be before start year" case)
- [x] Repeat the above for the Year field on Awards & Honours
- [x] Open an existing Education entry for editing — confirm no error messages appear on load before the user has interacted with the year fields
- [x] Cancel out of a form with a touched/invalid field, then reopen — confirm errors are cleared
- [x] Confirm the "Currently enrolled" checkbox disables the End Year field and suppresses its validation

E2E front end tests coming in next PR. Separate PR because its the first time we'll have E2E tests so treating it as different scope

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [ ] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [x] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

> If applicable, add screenshots to help explain your changes

<details>
<summary>Click to expand screenshots</summary>

Error text shown as well as greyed out save buttons when year values are invalid:

<img width="833" height="616" alt="Screenshot 2026-03-15 at 1 09 23 PM" src="https://github.com/user-attachments/assets/a083ff53-3415-4f27-841e-234897c483e6" />

Gone once year values are updated to be correctly within the ranges:

<img width="830" height="620" alt="Screenshot 2026-03-15 at 1 10 08 PM" src="https://github.com/user-attachments/assets/d22e971a-8d64-452e-8bc9-8adf7a78a8a3" />


</details>
