### PR TITLE
[Stack 2/3] backend skills-by-expertise payload and PDF support

### DIFF
--- a/src/api/app.py
+++ b/src/api/app.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import base64
-from collections import Counter
+from collections import Counter, defaultdict
 import hashlib
 import hmac
 import json
@@ -2163,10 +2163,10 @@ def download_resume_pdf(resume_id: str):
     try:
         # 1. Get the core project resume data
         item = get_resume_item(engine=engine, resume_id=resume_id)
-        
+
         from sqlalchemy import text
         with engine.connect() as conn:
-            # --- NEW: Get User ID first to fetch their data ---
+            # Resolve owning user so all resume sections come from one payload source.
             user_row = conn.execute(text("""
                 SELECT po.user_id 
                 FROM portfolios po
@@ -2177,33 +2177,21 @@ def download_resume_pdf(resume_id: str):
             
             if not user_row:
                 raise HTTPException(status_code=404, detail="User not found for this resume")
-            
-            uid = user_row["user_id"]
 
-            # --- NEW: Fetch Education and Awards ---
-            edu_rows = conn.execute(text("""
-                SELECT institution, degree, field_of_study, start_year, end_year, is_current, description
-                FROM education_entries WHERE user_id = :uid
-                ORDER BY start_year DESC NULLS LAST
-            """), {"uid": uid}).mappings().all()
+            uid = str(user_row["user_id"])
+            payload = _build_resume_payload_for_user(user_id=uid, db=conn)
 
-            award_rows = conn.execute(text("""
-                SELECT title, issuer, awarded_year, description
-                FROM award_entries WHERE user_id = :uid
-                ORDER BY awarded_year DESC NULLS LAST
-            """), {"uid": uid}).mappings().all()
-
-            # --- Existing Config/Filters Logic ---
             config_result = conn.execute(text("""
                 SELECT config_json FROM user_config WHERE user_id = :uid
             """), {"uid": uid}).mappings().first()
-            
+
             user_config = config_result["config_json"] if config_result else {}
             filters = user_config.get("resume_filters", {})
 
-        # 2. Inject the data into the 'item' dict so the exporter sees it
-        item["education"] = [dict(r) for r in edu_rows]
-        item["awards"] = [dict(r) for r in award_rows]
+        # 2. Inject standardized payload sections for exporter rendering.
+        item["education"] = payload.get("education") or []
+        item["awards"] = payload.get("awards") or []
+        item["skills_by_expertise"] = payload.get("skills_by_expertise") or _empty_skills_by_expertise()
 
     except KeyError:
         raise HTTPException(status_code=404, detail="Resume item not found")
@@ -3252,6 +3240,7 @@ SKILL_EXPERTISE_THRESHOLDS = {
     "familiar":      0.30,
     # anything below 0.30 → "exposure"
 }
+SKILL_EXPERTISE_ORDER = ("expert", "proficient", "familiar", "exposure")
 
 
 def bucket_skill_expertise(probability: float) -> str:
@@ -3298,6 +3287,70 @@ def _bucket_skills_from_rows(skill_rows: list) -> List[Dict[str, Any]]:
         })
     bucketed.sort(key=lambda x: x["probability"], reverse=True)
     return bucketed
+
+
+def _empty_skills_by_expertise() -> Dict[str, List[Dict[str, Any]]]:
+    return {level: [] for level in SKILL_EXPERTISE_ORDER}
+
+
+def _group_skills_by_expertise(projects: List[Dict[str, Any]]) -> Dict[str, List[Dict[str, Any]]]:
+    """
+    Build deterministic expertise buckets from projects[*].skills.
+
+    Rules:
+    - dedupe by case-insensitive skill name
+    - keep the highest-probability instance
+    - each skill appears in exactly one expertise bucket
+    - sort each bucket by probability DESC then name ASC (case-insensitive)
+    """
+    best_by_name: Dict[str, Dict[str, Any]] = {}
+
+    for project in projects or []:
+        skills = project.get("skills") or []
+        if not isinstance(skills, list):
+            continue
+
+        for raw_skill in skills:
+            if not isinstance(raw_skill, dict):
+                continue
+
+            name = str(raw_skill.get("name") or "").strip()
+            if not name:
+                continue
+
+            try:
+                prob = float(raw_skill.get("probability") or 0.0)
+            except (TypeError, ValueError):
+                prob = 0.0
+            prob = min(max(prob, 0.0), 1.0)
+
+            raw_expertise = str(raw_skill.get("expertise") or "").strip().casefold()
+            expertise = raw_expertise if raw_expertise in SKILL_EXPERTISE_ORDER else bucket_skill_expertise(prob)
+
+            candidate = {
+                "name": name,
+                "probability": prob,
+                "expertise": expertise,
+            }
+            key = name.casefold()
+            existing = best_by_name.get(key)
+            if not existing:
+                best_by_name[key] = candidate
+                continue
+
+            if candidate["probability"] > existing["probability"]:
+                best_by_name[key] = candidate
+            elif candidate["probability"] == existing["probability"] and candidate["name"].casefold() < existing["name"].casefold():
+                best_by_name[key] = candidate
+
+    grouped = _empty_skills_by_expertise()
+    for skill in best_by_name.values():
+        grouped[skill["expertise"]].append(skill)
+
+    for level in SKILL_EXPERTISE_ORDER:
+        grouped[level].sort(key=lambda row: (-float(row.get("probability") or 0.0), str(row.get("name") or "").casefold()))
+
+    return grouped
 
 
 def _normalize_evidence(evidence_json: Optional[Dict[str, Any]]) -> Dict[str, Any]:
@@ -3560,26 +3613,16 @@ def _award_row_to_out(row) -> Dict[str, Any]:
         "updated_at": r["updated_at"].isoformat() if hasattr(r["updated_at"], "isoformat") else str(r["updated_at"]),
     }
 
-# ---------------------------------------------------------------------------
-# Resume composite payload
-# GET /users/{user_id}/resume-payload
-# ---------------------------------------------------------------------------
 
-@app.get("/users/{user_id}/resume-payload")
-def get_resume_payload(user_id: str, db: Session = Depends(get_db)):
+def _build_resume_payload_for_user(user_id: str, db) -> Dict[str, Any]:
     """
-    Returns the full one-page resume data contract:
-      - education entries
-      - awards entries
-      - bucketed skills (derived from latest analysis per project)
-      - normalized contribution/impact evidence per project
+    Returns the full one-page resume payload for a user.
+    Shared by GET /users/{user_id}/resume-payload and resume PDF generation.
     """
-    # 1. Verify user exists
     row = db.execute(text("SELECT 1 FROM users WHERE id = :uid"), {"uid": user_id}).scalar()
     if not row:
         raise HTTPException(status_code=404, detail="User not found")
 
-    # 2. Education
     edu_rows = db.execute(
         text(
             """
@@ -3593,7 +3636,6 @@ def get_resume_payload(user_id: str, db: Session = Depends(get_db)):
         {"uid": user_id},
     ).mappings().all()
 
-    # 3. Awards
     award_rows = db.execute(
         text(
             """
@@ -3606,7 +3648,6 @@ def get_resume_payload(user_id: str, db: Session = Depends(get_db)):
         {"uid": user_id},
     ).mappings().all()
 
-    # 4. Projects with their evidence payloads
     project_rows = db.execute(
         text(
             """
@@ -3624,24 +3665,23 @@ def get_resume_payload(user_id: str, db: Session = Depends(get_db)):
         {"uid": user_id},
     ).mappings().all()
 
-    # 5. Skills via normalized tables: latest analysis per project → analysis_skills → skills
     skill_rows = db.execute(
         text(
             """
             SELECT
-                p.id        AS project_id,
+                p.id AS project_id,
                 sk.skill_name,
                 ask.confidence
             FROM projects p
             JOIN portfolios pf ON pf.id = p.portfolio_id
-            JOIN snapshots sn ON sn.project_id = p.id
             JOIN LATERAL (
-                SELECT id
-                FROM analyses
-                WHERE snapshot_id IN (
-                    SELECT id FROM snapshots WHERE project_id = p.id
-                )
-                ORDER BY created_at DESC
+                SELECT a.id
+                FROM analyses a
+                JOIN snapshots s ON s.id = a.snapshot_id
+                WHERE s.project_id = p.id
+                  AND a.analysis_type = 'local_ml'
+                  AND a.status = 'complete'
+                ORDER BY a.completed_at DESC NULLS LAST, a.created_at DESC, a.id DESC
                 LIMIT 1
             ) latest_a ON true
             JOIN analysis_skills ask ON ask.analysis_id = latest_a.id
@@ -3652,8 +3692,6 @@ def get_resume_payload(user_id: str, db: Session = Depends(get_db)):
         {"uid": user_id},
     ).mappings().all()
 
-    # Group skills by project_id for O(1) lookup below
-    from collections import defaultdict
     skills_by_project: Dict[str, list] = defaultdict(list)
     for sr in skill_rows:
         skills_by_project[str(sr["project_id"])].append(sr)
@@ -3665,17 +3703,37 @@ def get_resume_payload(user_id: str, db: Session = Depends(get_db)):
         if isinstance(evidence_json, str):
             evidence_json = json.loads(evidence_json)
 
-        projects_out.append({
-            "project_id": pid,
-            "project_name": pr.get("project_name"),
-            "user_role": pr.get("user_role"),
-            "skills": _bucket_skills_from_rows(skills_by_project[pid]),
-            "evidence": _normalize_evidence(evidence_json),
-        })
+        projects_out.append(
+            {
+                "project_id": pid,
+                "project_name": pr.get("project_name"),
+                "user_role": pr.get("user_role"),
+                "skills": _bucket_skills_from_rows(skills_by_project[pid]),
+                "evidence": _normalize_evidence(evidence_json),
+            }
+        )
 
     return {
         "user_id": user_id,
         "education": [_education_row_to_out(r) for r in edu_rows],
         "awards": [_award_row_to_out(r) for r in award_rows],
         "projects": projects_out,
+        "skills_by_expertise": _group_skills_by_expertise(projects_out),
     }
+
+
+# ---------------------------------------------------------------------------
+# Resume composite payload
+# GET /users/{user_id}/resume-payload
+# ---------------------------------------------------------------------------
+
+@app.get("/users/{user_id}/resume-payload")
+def get_resume_payload(user_id: str, db: Session = Depends(get_db)):
+    """
+    Returns the full one-page resume data contract:
+      - education entries
+      - awards entries
+      - bucketed skills (derived from latest analysis per project)
+      - normalized contribution/impact evidence per project
+    """
+    return _build_resume_payload_for_user(user_id=user_id, db=db)

--- a/src/api/pdf_exporter.py
+++ b/src/api/pdf_exporter.py
@@ -10,6 +10,14 @@ import logging
 from io import BytesIO
 
 logger = logging.getLogger(__name__)
+SKILL_EXPERTISE_ORDER = ("expert", "proficient", "familiar", "exposure")
+SKILL_EXPERTISE_LABELS = {
+    "expert": "Expert",
+    "proficient": "Proficient",
+    "familiar": "Familiar",
+    "exposure": "Exposure",
+}
+MAX_SKILLS_PER_EXPERTISE_LINE = 6
 
 
 def materialize_blob_to_tempfile(blob, default_ext=".png"):
@@ -321,10 +329,19 @@ def _normalize_resume_filters(filters: dict) -> dict:
         "show_evidence": _as_bool(raw.get("show_evidence"), True),
         "show_education": _as_bool(raw.get("show_education"), True),
         "show_awards": _as_bool(raw.get("show_awards"), True),
+        "show_skills_by_expertise": _as_bool(raw.get("show_skills_by_expertise"), True),
     }
 
     # Backward compatibility logic
-    new_keys = {"show_project_profile", "show_metrics", "show_tech_stack", "show_evidence", "show_education", "show_awards"}
+    new_keys = {
+        "show_project_profile",
+        "show_metrics",
+        "show_tech_stack",
+        "show_evidence",
+        "show_education",
+        "show_awards",
+        "show_skills_by_expertise",
+    }
     if (
         not any(k in raw for k in new_keys)
         and not out["show_summary"]
@@ -357,6 +374,7 @@ def export_resume_item_pdf_bytes(resume_item: dict, filters: dict = None) -> byt
     show_evidence = opts["show_evidence"]
     show_education = opts["show_education"]
     show_awards = opts["show_awards"]
+    show_skills_by_expertise = opts["show_skills_by_expertise"]
 
     content = resume_item.get("content") or {}
     if not isinstance(content, dict):
@@ -478,6 +496,44 @@ def export_resume_item_pdf_bytes(resume_item: dict, filters: dict = None) -> byt
                 text = f"• {title_awd} - {issuer} ({yr})"
                 elements.append(Paragraph(text, styles["Normal"]))
             elements.append(Spacer(1, 12))
+
+    if show_skills_by_expertise:
+        raw_buckets = resume_item.get("skills_by_expertise")
+        skill_buckets = raw_buckets if isinstance(raw_buckets, dict) else {}
+        has_grouped_skills = any(
+            isinstance(skill_buckets.get(level), list) and bool(skill_buckets.get(level))
+            for level in SKILL_EXPERTISE_ORDER
+        )
+        if has_grouped_skills:
+            elements.append(Paragraph("Skills by Expertise", styles["Heading2"]))
+            elements.append(Spacer(1, 6))
+
+            for level in SKILL_EXPERTISE_ORDER:
+                rows = skill_buckets.get(level) or []
+                if not isinstance(rows, list) or not rows:
+                    continue
+
+                names = []
+                for row in rows:
+                    if isinstance(row, dict):
+                        name = str(row.get("name") or row.get("skill") or "").strip()
+                    else:
+                        name = str(row).strip()
+                    if name:
+                        names.append(name)
+
+                if not names:
+                    continue
+
+                visible = names[:MAX_SKILLS_PER_EXPERTISE_LINE]
+                overflow = max(0, len(names) - len(visible))
+                line = f"{SKILL_EXPERTISE_LABELS[level]}: {', '.join(visible)}"
+                if overflow > 0:
+                    line += f" (+{overflow} more)"
+                elements.append(Paragraph(line, styles["Normal"]))
+                elements.append(Spacer(1, 4))
+
+            elements.append(Spacer(1, 8))
 
     if show_metrics:
         metrics = content.get("metrics") if isinstance(content.get("metrics"), dict) else {}

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -2217,7 +2217,12 @@ def test_portfolio_showcase_upsert_logic(engine):
         assert final_content["description"] == "Updated Version"
 
 
-from src.api.app import bucket_skill_expertise, _normalize_evidence, _bucket_skills_from_rows
+from src.api.app import (
+    bucket_skill_expertise,
+    _normalize_evidence,
+    _bucket_skills_from_rows,
+    _group_skills_by_expertise,
+)
 
 
 # ---------------------------------------------------------------------------
@@ -2332,6 +2337,37 @@ def test_bucket_skills_from_rows_null_confidence():
     rows = [{"skill_name": "Go", "confidence": None}]
     result = _bucket_skills_from_rows(rows)
     assert result[0]["expertise"] == "exposure"
+
+
+def test_group_skills_by_expertise_dedupes_and_sorts():
+    projects = [
+        {
+            "project_id": "p1",
+            "skills": [
+                {"name": "Python", "probability": 0.72, "expertise": "proficient"},
+                {"name": "React", "probability": 0.50, "expertise": "familiar"},
+            ],
+        },
+        {
+            "project_id": "p2",
+            "skills": [
+                {"name": "python", "probability": 0.91, "expertise": "expert"},
+                {"name": "Rust", "probability": 0.91, "expertise": "expert"},
+            ],
+        },
+    ]
+
+    grouped = _group_skills_by_expertise(projects)
+
+    # Python appears once with highest confidence and assigned to one bucket.
+    assert grouped["expert"][0]["name"] == "python"
+    assert grouped["expert"][0]["probability"] == 0.91
+    assert [row["name"] for row in grouped["proficient"]] == []
+
+    # Tie on probability uses name ASC.
+    assert [row["name"] for row in grouped["expert"]] == ["python", "Rust"]
+    assert [row["name"] for row in grouped["familiar"]] == ["React"]
+    assert grouped["exposure"] == []
 
 
 # ---------------------------------------------------------------------------
@@ -2513,6 +2549,8 @@ def test_resume_payload_shape(client, engine):
     assert "education" in payload
     assert "awards" in payload
     assert "projects" in payload
+    assert "skills_by_expertise" in payload
+    assert set(payload["skills_by_expertise"].keys()) == {"expert", "proficient", "familiar", "exposure"}
 
     # Education present
     assert any(e["institution"] == "State University" for e in payload["education"])
@@ -2551,6 +2589,160 @@ def test_resume_payload_project_evidence_schema(client, engine):
         assert "contributions" in evidence
         assert "impact" in evidence
         assert "extra" in evidence
+
+
+def test_resume_payload_skills_by_expertise_deduped_and_sorted(client, engine):
+    info = _register_user(client, email="resume_skills_grouping@example.com")
+    user_id = info["user_id"]
+    portfolio_id = info["portfolio_id"]
+    project_a = _u()
+    project_b = _u()
+    snapshot_a = _u()
+    snapshot_b = _u()
+
+    with engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO projects (id, portfolio_id, name) VALUES (:id, :pf, 'Resume A')"),
+            {"id": project_a, "pf": portfolio_id},
+        )
+        conn.execute(
+            text("INSERT INTO projects (id, portfolio_id, name) VALUES (:id, :pf, 'Resume B')"),
+            {"id": project_b, "pf": portfolio_id},
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO snapshots (id, project_id, source_zip_name, source_zip_sha256, snapshot_label)
+                VALUES
+                    (:s1, :p1, 'a.zip', :sha1, 'A'),
+                    (:s2, :p2, 'b.zip', :sha2, 'B')
+                """
+            ),
+            {"s1": snapshot_a, "p1": project_a, "sha1": "a" * 64, "s2": snapshot_b, "p2": project_b, "sha2": "b" * 64},
+        )
+
+        conn.execute(
+            text(
+                """
+                INSERT INTO analyses (id, snapshot_id, analysis_type, status, output_json, created_at, completed_at)
+                VALUES
+                    (:a1, :s1, 'local_ml', 'complete', '{}'::jsonb, NOW() - INTERVAL '2 minute', NOW() - INTERVAL '2 minute'),
+                    (:a2, :s2, 'local_ml', 'complete', '{}'::jsonb, NOW() - INTERVAL '1 minute', NOW() - INTERVAL '1 minute')
+                """
+            ),
+            {"a1": _u(), "s1": snapshot_a, "a2": _u(), "s2": snapshot_b},
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO skills (skill_name, category)
+                VALUES ('python', 'language'), ('rust', 'language'), ('react', 'framework')
+                ON CONFLICT DO NOTHING
+                """
+            )
+        )
+        py_id = conn.execute(text("SELECT id FROM skills WHERE skill_name='python'")).scalar_one()
+        rs_id = conn.execute(text("SELECT id FROM skills WHERE skill_name='rust'")).scalar_one()
+        re_id = conn.execute(text("SELECT id FROM skills WHERE skill_name='react'")).scalar_one()
+        analysis_rows = conn.execute(
+            text(
+                """
+                SELECT id, snapshot_id
+                FROM analyses
+                WHERE (snapshot_id = :s1 OR snapshot_id = :s2)
+                  AND analysis_type = 'local_ml'
+                """
+            ),
+            {"s1": snapshot_a, "s2": snapshot_b},
+        ).mappings().all()
+        analysis_by_snapshot = {str(row["snapshot_id"]): str(row["id"]) for row in analysis_rows}
+        analysis_a = analysis_by_snapshot[snapshot_a]
+        analysis_b = analysis_by_snapshot[snapshot_b]
+        conn.execute(
+            text(
+                """
+                INSERT INTO analysis_skills (analysis_id, skill_id, confidence)
+                VALUES
+                    (:a1, :py, 0.62),
+                    (:a1, :re, 0.52),
+                    (:a2, :py, 0.93),
+                    (:a2, :rs, 0.93)
+                """
+            ),
+            {"a1": analysis_a, "a2": analysis_b, "py": py_id, "re": re_id, "rs": rs_id},
+        )
+
+    r = client.get(f"/users/{user_id}/resume-payload")
+    assert r.status_code == 200
+    grouped = r.json()["skills_by_expertise"]
+
+    # Python deduped to highest probability and appears once in expert.
+    assert [row["name"] for row in grouped["expert"]] == ["python", "rust"]
+    assert [row["name"] for row in grouped["proficient"]] == []
+    assert [row["name"] for row in grouped["familiar"]] == ["react"]
+
+
+def test_resume_payload_prefers_latest_completed_local_ml_for_skills(client, engine):
+    info = _register_user(client, email="resume_local_ml_preferred@example.com")
+    user_id = info["user_id"]
+    portfolio_id = info["portfolio_id"]
+    project_id = _u()
+    snapshot_id = _u()
+    local_ml_id = _u()
+    external_llm_id = _u()
+
+    with engine.begin() as conn:
+        conn.execute(
+            text("INSERT INTO projects (id, portfolio_id, name) VALUES (:id, :pf, 'Resume Local ML Preferred')"),
+            {"id": project_id, "pf": portfolio_id},
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO snapshots (id, project_id, source_zip_name, source_zip_sha256, snapshot_label)
+                VALUES (:sid, :pid, 'resume.zip', :sha, 'S1')
+                """
+            ),
+            {"sid": snapshot_id, "pid": project_id, "sha": "c" * 64},
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO analyses (id, snapshot_id, analysis_type, status, output_json, created_at, completed_at)
+                VALUES
+                    (:ml, :sid, 'local_ml', 'complete', '{}'::jsonb, NOW() - INTERVAL '2 minute', NOW() - INTERVAL '2 minute'),
+                    (:ext, :sid, 'external_llm', 'complete', '{}'::jsonb, NOW() - INTERVAL '1 minute', NOW() - INTERVAL '1 minute')
+                """
+            ),
+            {"ml": local_ml_id, "ext": external_llm_id, "sid": snapshot_id},
+        )
+        conn.execute(
+            text(
+                """
+                INSERT INTO skills (skill_name, category)
+                VALUES ('python', 'language')
+                ON CONFLICT DO NOTHING
+                """
+            )
+        )
+        py_id = conn.execute(text("SELECT id FROM skills WHERE skill_name='python'")).scalar_one()
+        conn.execute(
+            text(
+                """
+                INSERT INTO analysis_skills (analysis_id, skill_id, confidence)
+                VALUES (:aid, :sid, 0.91)
+                """
+            ),
+            {"aid": local_ml_id, "sid": py_id},
+        )
+
+    r = client.get(f"/users/{user_id}/resume-payload")
+    assert r.status_code == 200
+    payload = r.json()
+
+    project = next(p for p in payload["projects"] if p["project_id"] == project_id)
+    assert [row["name"] for row in project["skills"]] == ["python"]
+    assert [row["name"] for row in payload["skills_by_expertise"]["expert"]] == ["python"]
 
 
 def test_resume_payload_unknown_user_returns_404(client):
@@ -2677,6 +2869,12 @@ def test_export_resume_item_pdf_education_awards_content():
                 "awarded_year": "2025"
             }
         ],
+        "skills_by_expertise": {
+            "expert": [{"name": "Rust"}, {"name": "PostgreSQL"}],
+            "proficient": [{"name": "Python"}],
+            "familiar": [],
+            "exposure": [],
+        },
         "content": {
             "summary_text": "A full-stack developer focusing on React and Python.",
             "project": {"name": "Artifact Miner", "id": "proj-999"}
@@ -2704,6 +2902,7 @@ def test_export_resume_item_pdf_education_awards_content():
     assert "Artifact Miner" in page_text
     assert "Education" in page_text
     assert "Awards & Honors" in page_text
+    assert "Skills by Expertise" in page_text
 
     
     assert "University of British Columbia" in page_text
@@ -2715,11 +2914,17 @@ def test_export_resume_item_pdf_education_awards_content():
     assert "Hackathon Winner" in page_text
     assert "Major League Hacking" in page_text
     assert "(2025)" in page_text
+    assert "Expert:" in page_text
+    assert "Rust" in page_text
+    assert "PostgreSQL" in page_text
+    assert "Proficient:" in page_text
+    assert "Python" in page_text
 
 def test_resume_pdf_filters_toggles():
     """Verifies that sections are omitted when filters are set to False."""
     mock_resume_item = {
         "education": [{"institution": "UBC", "degree": "CS", "end_year": "2026"}],
+        "skills_by_expertise": {"expert": [{"name": "Rust"}]},
         "content": {"project": {"name": "Hidden Project"}}
     }
     
@@ -2732,3 +2937,49 @@ def test_resume_pdf_filters_toggles():
     
     assert "Education" not in page_text
     assert "UBC" not in page_text
+
+
+def test_resume_pdf_skills_by_expertise_cap_and_overflow_note():
+    mock_resume_item = {
+        "skills_by_expertise": {
+            "expert": [
+                {"name": "Rust"},
+                {"name": "Python"},
+                {"name": "Go"},
+                {"name": "SQL"},
+                {"name": "TypeScript"},
+                {"name": "React"},
+                {"name": "FastAPI"},
+            ]
+        },
+        "content": {"project": {"name": "Skill Dense Project"}},
+    }
+
+    pdf_bytes = export_resume_item_pdf_bytes(mock_resume_item, filters={"show_skills_by_expertise": True})
+    page_text = PdfReader(io.BytesIO(pdf_bytes)).pages[0].extract_text()
+
+    assert "Skills by Expertise" in page_text
+    assert "Expert:" in page_text
+    for name in ["Rust", "Python", "Go", "SQL", "TypeScript", "React"]:
+        assert name in page_text
+    assert "+1 more" in page_text
+    assert "FastAPI" not in page_text
+
+
+def test_resume_pdf_skills_by_expertise_toggle_hidden():
+    mock_resume_item = {
+        "skills_by_expertise": {
+            "expert": [{"name": "Rust"}],
+            "proficient": [{"name": "Python"}],
+        },
+        "content": {"project": {"name": "Hidden Skills Project"}},
+    }
+
+    pdf_bytes = export_resume_item_pdf_bytes(
+        mock_resume_item,
+        filters={"show_skills_by_expertise": False},
+    )
+    page_text = PdfReader(io.BytesIO(pdf_bytes)).pages[0].extract_text()
+
+    assert "Skills by Expertise" not in page_text
+    assert "Expert: Rust" not in page_text


### PR DESCRIPTION
## 📝 Description

This PR is part 2 of a 3-PR stack for issue #291 and contains backend resume payload/rendering work.

- Adds deterministic `skills_by_expertise` generation in resume payload construction.
- Uses latest completed `local_ml` analysis for resume skills extraction.
- Adds resume PDF support for `Skills by Expertise` section.
- Adds/updates backend tests for grouping and payload behavior.

Dependencies:
- Stacked on PR1 (`stack/pr1-frontend-security`).

**Closes:** N/A (part 2 of #291 stack)

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] Testing for this PR is intentionally deferred to PR3 to keep stacked PR size within course line limits.
- [x] Full stack validation is recorded in PR3, where all relevant checks pass.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [ ] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [ ] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

N/A

</details>
