### PR TITLE
[Stack 3/3] resume skills UI integration

### DIFF
--- a/docs/api/README_API.md
+++ b/docs/api/README_API.md
@@ -128,7 +128,10 @@ Resume PDF filters are read from `config.resume_filters` (optional):
   "show_project_profile": true,
   "show_metrics": true,
   "show_tech_stack": true,
-  "show_evidence": true
+  "show_evidence": true,
+  "show_education": true,
+  "show_awards": true,
+  "show_skills_by_expertise": true
 }
 ```
 
@@ -325,9 +328,34 @@ Resume PDF filters are read from `config.resume_filters` (optional):
 - `GET /resume/{resume_id}/pdf`
   - Returns PDF bytes.
   - Reads display/toggle filters from owning user's `user_config.resume_filters`.
+  - Includes `Education`, `Awards & Honors`, and `Skills by Expertise` sections when enabled by filters and data is present.
 
 - `DELETE /resume/{resume_id}`
   - Deletes stored resume artifact.
+
+- `POST /users/{user_id}/education`
+- `GET /users/{user_id}/education`
+- `PUT /users/{user_id}/education/{entry_id}`
+- `DELETE /users/{user_id}/education/{entry_id}`
+  - Manage education entries used by one-page resume composition.
+
+- `POST /users/{user_id}/awards`
+- `GET /users/{user_id}/awards`
+- `PUT /users/{user_id}/awards/{entry_id}`
+- `DELETE /users/{user_id}/awards/{entry_id}`
+  - Manage awards entries used by one-page resume composition.
+
+- `GET /users/{user_id}/resume-payload`
+  - Returns a normalized payload for one-page resume rendering.
+  - Shape:
+    - `user_id`
+    - `education[]`
+    - `awards[]`
+    - `projects[]` (each project contains `skills[]` + normalized `evidence`)
+    - `skills_by_expertise`:
+      - `expert[]`, `proficient[]`, `familiar[]`, `exposure[]`
+      - deterministic dedupe by case-insensitive skill name (keeps highest probability)
+      - per-bucket sort: probability desc, then name asc (case-insensitive)
 
 ### Identity and Linking
 - `POST /users/{user_id}/identity/rules`

--- a/frontend/src/Homepage.jsx
+++ b/frontend/src/Homepage.jsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { API_BASE_URL, authApi, dashboardApi, projectApi, resumeApi, userConfigApi } from './api';
+import ResumeSkillsSection from './ResumeSkillsSection';
 
 const TOKEN_STORAGE_KEY = 'artifactMiner.authToken';
 const ANALYSIS_POLL_INTERVAL_MS = 5000;
@@ -1790,6 +1791,7 @@ function Homepage() {
   const [resumeEducation, setResumeEducation] = useState([]);
   const [resumeAwards, setResumeAwards] = useState([]);
   const [resumeProjects, setResumeProjects] = useState([]);
+  const [resumeSkillsByExpertise, setResumeSkillsByExpertise] = useState(null);
   const [resumeLoading, setResumeLoading] = useState(false);
   const [resumeSaving, setResumeSaving] = useState(false);
   const [editingEduId, setEditingEduId] = useState(null);
@@ -1810,6 +1812,7 @@ function Homepage() {
       setResumeEducation(data.education || []);
       setResumeAwards(data.awards || []);
       setResumeProjects(data.projects || []);
+      setResumeSkillsByExpertise(data.skills_by_expertise || null);
     } catch (err) {
       setDashboardError(err.message || 'Unable to load resume data.');
     } finally {
@@ -3499,26 +3502,10 @@ function Homepage() {
                     ))}
                   </section>
 
-                  {resumeProjects.some((p) => p.skills.length > 0) && (
-                    <section className="panel">
-                      <h2>Skills by Project</h2>
-                      <p className="muted">Derived from your project analyses. Included when generating your resume PDF.</p>
-                      <div className="stack-block">
-                        {resumeProjects.map((p) => (
-                          p.skills.length > 0 && (
-                            <div key={p.project_id}>
-                              <h3>{p.project_name || p.project_id}</h3>
-                              <div className="badge-row">
-                                {p.skills.map((s, i) => (
-                                  <span key={i} className="skill-badge">{s.name} <span className="muted">· {s.expertise}</span></span>
-                                ))}
-                              </div>
-                            </div>
-                          )
-                        ))}
-                      </div>
-                    </section>
-                  )}
+                  <ResumeSkillsSection
+                    skillsByExpertise={resumeSkillsByExpertise}
+                    projects={resumeProjects}
+                  />
                 </>
               )}
             </>

--- a/frontend/src/ResumeSkillsSection.jsx
+++ b/frontend/src/ResumeSkillsSection.jsx
@@ -1,0 +1,46 @@
+import React, { useMemo } from 'react';
+import {
+  SKILL_EXPERTISE_LABELS,
+  SKILL_EXPERTISE_ORDER,
+  resolveSkillsByExpertise,
+} from './resumeSkills';
+
+function ResumeSkillsSection({ skillsByExpertise, projects }) {
+  const grouped = useMemo(
+    () => resolveSkillsByExpertise(skillsByExpertise, projects),
+    [skillsByExpertise, projects]
+  );
+  const hasAnySkills = SKILL_EXPERTISE_ORDER.some((level) => grouped[level].length > 0);
+
+  return (
+    <section className="panel">
+      <h2>Skills by Expertise</h2>
+      <p className="muted">Derived from your project analyses. Included when generating your resume PDF.</p>
+      {!hasAnySkills && (
+        <p className="muted">No skills detected yet. Analyze projects to populate expertise groups.</p>
+      )}
+      {hasAnySkills && (
+        <div className="stack-block">
+          {SKILL_EXPERTISE_ORDER.map((level) => {
+            const rows = grouped[level];
+            if (!rows.length) return null;
+            return (
+              <div key={level}>
+                <h3>{SKILL_EXPERTISE_LABELS[level]}</h3>
+                <div className="badge-row">
+                  {rows.map((skill) => (
+                    <span key={`${level}-${skill.name.toLowerCase()}`} className="skill-badge">
+                      {skill.name}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            );
+          })}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export default ResumeSkillsSection;

--- a/frontend/src/ResumeSkillsSection.test.js
+++ b/frontend/src/ResumeSkillsSection.test.js
@@ -1,0 +1,55 @@
+import { render, screen } from '@testing-library/react';
+import ResumeSkillsSection from './ResumeSkillsSection';
+
+test('renders expertise headings in fixed order', () => {
+  render(
+    <ResumeSkillsSection
+      skillsByExpertise={{
+        expert: [{ name: 'Rust', expertise: 'expert', probability: 0.9 }],
+        proficient: [{ name: 'Python', expertise: 'proficient', probability: 0.7 }],
+        familiar: [{ name: 'Go', expertise: 'familiar', probability: 0.5 }],
+        exposure: [{ name: 'HTML', expertise: 'exposure', probability: 0.2 }],
+      }}
+      projects={[]}
+    />
+  );
+
+  const headings = screen.getAllByRole('heading', { level: 3 }).map((node) => node.textContent);
+  expect(headings).toEqual(['Expert', 'Proficient', 'Familiar', 'Exposure']);
+});
+
+test('falls back to projects skills when grouped payload is absent', () => {
+  render(
+    <ResumeSkillsSection
+      skillsByExpertise={null}
+      projects={[
+        {
+          project_id: 'p1',
+          skills: [
+            { name: 'Python', expertise: 'proficient', probability: 0.7 },
+            { name: 'React', expertise: 'familiar', probability: 0.45 },
+          ],
+        },
+        {
+          project_id: 'p2',
+          skills: [
+            { name: 'python', expertise: 'expert', probability: 0.92 },
+          ],
+        },
+      ]}
+    />
+  );
+
+  expect(screen.getByRole('heading', { name: 'Expert' })).toBeInTheDocument();
+  expect(screen.getByText('python')).toBeInTheDocument();
+  expect(screen.getAllByText(/python/i)).toHaveLength(1);
+  expect(screen.getByRole('heading', { name: 'Familiar' })).toBeInTheDocument();
+  expect(screen.getByText('React')).toBeInTheDocument();
+});
+
+test('shows empty state when no skills exist', () => {
+  render(<ResumeSkillsSection skillsByExpertise={null} projects={[]} />);
+  expect(
+    screen.getByText('No skills detected yet. Analyze projects to populate expertise groups.')
+  ).toBeInTheDocument();
+});

--- a/frontend/src/resumeSkills.js
+++ b/frontend/src/resumeSkills.js
@@ -1,0 +1,86 @@
+export const SKILL_EXPERTISE_ORDER = ['expert', 'proficient', 'familiar', 'exposure'];
+
+export const SKILL_EXPERTISE_LABELS = {
+  expert: 'Expert',
+  proficient: 'Proficient',
+  familiar: 'Familiar',
+  exposure: 'Exposure',
+};
+
+function normalizeSkillName(entry) {
+  if (entry && typeof entry === 'object') {
+    const name = String(entry.name || entry.skill || '').trim();
+    if (!name) return '';
+    return name;
+  }
+  return String(entry || '').trim();
+}
+
+export function normalizeSkillsByExpertise(raw) {
+  const source = raw && typeof raw === 'object' ? raw : {};
+  const out = {};
+
+  SKILL_EXPERTISE_ORDER.forEach((level) => {
+    const rows = Array.isArray(source[level]) ? source[level] : [];
+    out[level] = rows
+      .map((entry) => {
+        const name = normalizeSkillName(entry);
+        if (!name) return null;
+        const probability =
+          entry && typeof entry === 'object' && Number.isFinite(Number(entry.probability))
+            ? Number(entry.probability)
+            : null;
+        return { name, expertise: level, probability };
+      })
+      .filter(Boolean);
+  });
+
+  return out;
+}
+
+export function deriveSkillsByExpertiseFromProjects(projects) {
+  const bestByName = new Map();
+  const projectList = Array.isArray(projects) ? projects : [];
+
+  projectList.forEach((project) => {
+    const skills = Array.isArray(project?.skills) ? project.skills : [];
+    skills.forEach((skill) => {
+      const name = normalizeSkillName(skill);
+      if (!name) return;
+      const key = name.toLowerCase();
+      const probability = Number.isFinite(Number(skill?.probability)) ? Number(skill.probability) : 0;
+      const expertise = SKILL_EXPERTISE_ORDER.includes(skill?.expertise) ? skill.expertise : 'exposure';
+      const candidate = { name, expertise, probability };
+      const existing = bestByName.get(key);
+      if (!existing || candidate.probability > existing.probability) {
+        bestByName.set(key, candidate);
+      } else if (
+        candidate.probability === existing.probability &&
+        candidate.name.localeCompare(existing.name, undefined, { sensitivity: 'base' }) < 0
+      ) {
+        bestByName.set(key, candidate);
+      }
+    });
+  });
+
+  const grouped = normalizeSkillsByExpertise({});
+  bestByName.forEach((skill) => {
+    grouped[skill.expertise].push(skill);
+  });
+  SKILL_EXPERTISE_ORDER.forEach((level) => {
+    grouped[level].sort((a, b) => {
+      const diff = (b.probability || 0) - (a.probability || 0);
+      if (diff !== 0) return diff;
+      return a.name.localeCompare(b.name, undefined, { sensitivity: 'base' });
+    });
+  });
+
+  return grouped;
+}
+
+export function resolveSkillsByExpertise(skillsByExpertise, projects) {
+  const normalized = normalizeSkillsByExpertise(skillsByExpertise);
+  const hasAny = SKILL_EXPERTISE_ORDER.some((level) => normalized[level].length > 0);
+  if (hasAny) return normalized;
+  return deriveSkillsByExpertiseFromProjects(projects);
+}


### PR DESCRIPTION
## 📝 Description

This PR is part 3 of a 3-PR stack for issue #291 and includes frontend resume integration changes.

- Adds `ResumeSkillsSection` UI and skill grouping helpers.
- Integrates grouped skills into `Homepage` resume view.
- Adds frontend tests for grouped-skill rendering and fallback behavior.
- Updates API docs for resume payload and PDF filters.

Dependencies:
- Stacked on PR2 (`stack/pr2-backend-resume`).
- Dashboard filter CI fix was moved to PR1 so earlier stacked PRs also pass.

**Closes:** #291

---

## 🔧 Type of Change

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [x] ✨ New feature (non-breaking change that adds functionality)
- [ ] 💥 Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] 📚 Documentation added/updated
- [x] ✅ Test added/updated
- [ ] ♻️ Refactoring
- [ ] ⚡ Performance improvement

---

## 🧪 Testing

- [x] Manual testing completed for resume flow (upload/analyze project and verify skills appear under expertise groups).
- [x] `pytest` executed for affected paths and all tests pass.

---

## ✓ Checklist

- [x] 🤖 GenAI was used in generating the code and I have performed a self-review of my own code
- [x] 💬 I have commented my code where needed
- [x] 📖 I have made corresponding changes to the documentation
- [x] ⚠️ My changes generate no new warnings
- [x] ✅ I have added tests that prove my fix is effective or that my feature works and tests are passing locally
- [ ] 🔗 Any dependent changes have been merged and published in downstream modules
- [x] 📱 Any UI changes have been checked to work on desktop, tablet, and/or mobile

---

## 📸 Screenshots

<details>
<summary>Click to expand screenshots</summary>

N/A

</details>
